### PR TITLE
Fix dependency to o-colors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,6 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-colors": "~2.4.7"
+    "o-colors": "^2.3.17"
   }
 }


### PR DESCRIPTION
- Dependencies should be expressed as `^x.x.x`, to get all changes in a given major version.
- o-colors 2.3.17 should work perfectly well

@quarterto I haven't tested the branch locally, feel free to do so
