### PR TITLE
Add an inverted state for the premium label for use with dark backgrounds

### DIFF
--- a/scss/_states.scss
+++ b/scss/_states.scss
@@ -36,6 +36,10 @@ $o-labels-states: (
 		text: 'white',
 		background: 'black'
 	),
+	premium-inverted: (
+		text: 'black',
+		background: 'white'
+	),
 	brand: (
 		text: 'white',
 		background: 'claret'


### PR DESCRIPTION
From Sue and Rebecca.

(At some point still want to do some kind of parent dark-mode class name that things can switch appearance on automatically rather than having to override everything...  Is there an official name for this - would there be a better suffix than "inverted"?)

@JakeChampion you seem to have the most recent commits, you're it ;)