### PR TITLE
Add: commercial content label state

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Labels can have one of several states:
 - `closed`: old closed content state, default grey
 - `premium`: premium content state, default black
 - `brand`: FT brand label state, default claret
+- `commercial-content`: commercially promoted content (eg. native ads), default ?tbc?
 
 ```html
 <span class="o-labels">Label</span>
@@ -32,6 +33,7 @@ Labels can have one of several states:
 <span class="o-labels o-labels--closed">Closed</span>
 <span class="o-labels o-labels--premium">Premium</span>
 <span class="o-labels o-labels--brand">Brand</span>
+<span class="o-labels o-labels--commercial-content">Commercial Content</span>
 ```
 
 Use [o-typography](https://registry.origami.ft.com/components/o-typography) to control the sizing of labels. Use a label one size smaller than surrounding text, e.g. an `s` label with `m` text.

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -6,6 +6,7 @@
 <span class="o-labels o-labels--closed">Closed</span>
 <span class="o-labels o-labels--premium">Premium</span>
 <span class="o-labels o-labels--brand">Brand</span>
+<span class="o-labels o-labels--commercial-content">Commercial Content</span>
 
 <br><br>
 
@@ -17,6 +18,7 @@
 <span class="o-labels o-labels--closed o-labels--medium">Closed</span>
 <span class="o-labels o-labels--premium o-labels--medium">Premium</span>
 <span class="o-labels o-labels--brand o-labels--medium">Brand</span>
+<span class="o-labels o-labels--commercial-content o-labels--medium">Commercial Content</span>
 
 <br><br>
 

--- a/demos/src/states.mustache
+++ b/demos/src/states.mustache
@@ -6,3 +6,4 @@
 <span class="o-labels o-labels--closed">Closed</span>
 <span class="o-labels o-labels--premium">Premium</span>
 <span class="o-labels o-labels--brand">Brand</span>
+<span class="o-labels o-labels--commercial-content">Commercial Content</span>

--- a/scss/_states.scss
+++ b/scss/_states.scss
@@ -43,6 +43,10 @@ $o-labels-states: (
 	brand: (
 		text: 'white',
 		background: 'claret'
+	),
+	commercial-content: (
+		text: 'white',
+		background: 'section-green'
 	)
 ) !default;
 

--- a/scss/_states.scss
+++ b/scss/_states.scss
@@ -3,6 +3,8 @@
 /// @link http://registry.origami.ft.com/components/o-labels
 ////
 
+@include oColorsSetColor('o-labels-commercial-content', #00884A);
+
 /// States for normal/active/error and associated styles.
 /// Add to this map for more states.
 ///
@@ -46,7 +48,7 @@ $o-labels-states: (
 	),
 	commercial-content: (
 		text: 'white',
-		background: 'section-green'
+		background: 'o-labels-commercial-content'
 	)
 ) !default;
 


### PR DESCRIPTION
cc: @onishiweb 

A state for labelling content that is commercial / native advertising.

`o-labels--comercial-content`

(awaiting confirmation on background colour)