### PR TITLE
Design and variant overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ There are several size modifier classes which can be used to change the general 
 
 ```html
 <span class="o-labels o-labels--big">Big Label</span>
-<span class="o-labels o-labels--small">Small Label</span>
 ```
 
 Labels can also have one of several states. The available states depend on which brand you are using (there are no states for whitelabel branded components):
@@ -91,7 +90,7 @@ The `oLabelsBase` mixin is used to output default label styles, including the `o
 }
 ```
 
-The `oLabelsSize` mixin can be used to output a class for one of the label sizes. Valid sizes are `big` and `small`:
+The `oLabelsSize` mixin can be used to output a class for one of the label sizes. The only valid size currently is `big`:
 
 ```scss
 @include oLabelsSize('big');

--- a/demos/src/data/states-lifecycle.json
+++ b/demos/src/data/states-lifecycle.json
@@ -1,7 +1,7 @@
 {
 	"states": [
 		{
-			"id": "lifecycle-beta o-labels--wide",
+			"id": "lifecycle-beta",
 			"content": "Beta"
 		}
 	]

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -4,9 +4,6 @@ $o-labels-is-silent: false;
 @import "../../main";
 
 body {
+	@include oColorsFor('page', 'background');
 	margin: 1em;
-
-	@if oBrandGetCurrentBrand() == 'master' {
-		background-color: oColorsGetPaletteColor('paper');
-	}
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -5,4 +5,8 @@ $o-labels-is-silent: false;
 
 body {
 	margin: 1em;
+
+	@if oBrandGetCurrentBrand() == 'master' {
+		background-color: oColorsGetPaletteColor('paper');
+	}
 }

--- a/demos/src/sizes.mustache
+++ b/demos/src/sizes.mustache
@@ -2,5 +2,3 @@
 <span class="o-labels">Standard Label</span>
 
 <span class="o-labels o-labels--big">Big Label</span>
-
-<span class="o-labels o-labels--small">Small Label</span>

--- a/demos/src/typography.mustache
+++ b/demos/src/typography.mustache
@@ -9,8 +9,4 @@
 		This is a <span class="o-labels o-labels--big">Big Label</span> sat within a paragraph.
 	</p>
 
-	<p>
-		This is a <span class="o-labels o-labels--small">Small Label</span> sat within a paragraph.
-	</p>
-
 </div>

--- a/main.scss
+++ b/main.scss
@@ -16,9 +16,6 @@
 	@if _oLabelsSupports('big') {
 		@include oLabelsSize('big');
 	}
-	@if _oLabelsSupports('small') {
-		@include oLabelsSize('small');
-	}
 
 	// Label state variants
 	@each $state in $_o-labels-states {

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -39,10 +39,7 @@ $_o-labels-shared-brand-config: (
 			'lifecycle-beta': (
 				background-color: oColorsGetPaletteColor('paper'),
 				border-color: oColorsGetPaletteColor('black-20'),
-				text-color: oColorsGetPaletteColor('black-80'),
-				padding-vertical: oTypographySpacingSize(1),
-				padding-horizontal: oTypographySpacingSize(4),
-				text-transform: uppercase
+				text-color: oColorsGetPaletteColor('black-80')
 			)
 		)),
 		'supports-variants': (

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -13,19 +13,14 @@
 
 // Define shared brand configurations
 $_o-labels-shared-brand-config: (
-	font-scale: 0,
+	font-scale: -1,
 	padding-vertical: oTypographySpacingSize(1),
-	padding-horizontal: oTypographySpacingSize(2),
+	padding-horizontal: oTypographySpacingSize(3),
 	border-width: 1px,
 	'big': (
-		font-scale: 1,
+		font-scale: 0,
 		padding-vertical: oTypographySpacingSize(2),
-		padding-horizontal: oTypographySpacingSize(3)
-	),
-	'small': (
-		font-scale: -1,
-		padding-vertical: oTypographySpacingSize(1),
-		padding-horizontal: oTypographySpacingSize(1)
+		padding-horizontal: oTypographySpacingSize(4)
 	)
 );
 
@@ -33,8 +28,8 @@ $_o-labels-shared-brand-config: (
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-labels', 'master', (
 		'variables': map-merge($_o-labels-shared-brand-config, (
-			text-color: oColorsGetPaletteColor('white'),
-			background-color: oColorsGetPaletteColor('oxford'),
+			text-color: oColorsGetPaletteColor('black'),
+			background-color: oColorsGetPaletteColor('wheat'),
 			'content-commercial': (
 				background-color: oColorsGetTint('jade', 50)
 			),
@@ -43,8 +38,8 @@ $_o-labels-shared-brand-config: (
 			),
 			'lifecycle-beta': (
 				background-color: oColorsGetPaletteColor('paper'),
-				border-color: oColorsMix('black', 'paper', 20),
-				text-color: oColorsMix('black', 'paper', 80),
+				border-color: oColorsGetPaletteColor('black-20'),
+				text-color: oColorsGetPaletteColor('black-80'),
 				padding-vertical: oTypographySpacingSize(1),
 				padding-horizontal: oTypographySpacingSize(4),
 				text-transform: uppercase
@@ -52,8 +47,6 @@ $_o-labels-shared-brand-config: (
 		)),
 		'supports-variants': (
 			'big',
-			'small',
-			'wide',
 			'content-commercial',
 			'content-premium',
 			'lifecycle-beta'
@@ -104,7 +97,6 @@ $_o-labels-shared-brand-config: (
 		)),
 		'supports-variants': (
 			'big',
-			'small',
 			'support-active',
 			'support-dead',
 			'support-deprecated',
@@ -125,8 +117,7 @@ $_o-labels-shared-brand-config: (
 			background-color: oColorsMix('black', 'white', 10)
 		)),
 		'supports-variants': (
-			'big',
-			'small'
+			'big'
 		)
 	));
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -12,6 +12,7 @@
 		box-sizing: border-box;
 		margin: 0;
 		text-decoration: none;
+		text-transform: uppercase;
 		padding: (_oLabelsGet('padding-vertical') - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal') - _oLabelsGet('border-width'));
 		color: _oLabelsGet('text-color');
 		background-color: _oLabelsGet('background-color');
@@ -20,7 +21,7 @@
 }
 
 /// Size modifiers for labels.
-/// @param {String} $size - The label size to output styles for. One of `'big'` or `'small'`.
+/// @param {String} $size - The label size to output styles for. Currently only `'big'` is a valid size.
 /// @output The output includes the `.o-labels--SIZE` modifier class definition, which includes all overrides.
 /// @example scss - Big label styles
 ///   @include oLabelsSize('big');
@@ -33,7 +34,6 @@
 			font-size: nth(oTypographyGetScale(_oLabelsGet('font-scale', $size)), 1) * 1px;
 		}
 		padding: (_oLabelsGet('padding-vertical', $size) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $size) - _oLabelsGet('border-width'));
-		text-transform: _oLabelsGet('text-transform', $size);
 	}
 }
 
@@ -56,18 +56,12 @@
 	.o-labels--#{$state-name} {
 		background-color: _oLabelsGet('background-color', $variant);
 		border-color: _oLabelsGet('border-color', $variant);
-		text-transform: _oLabelsGet('text-transform', $variant);
 
 		// Set text colour or calculate based on background
 		@if _oLabelsGet('text-color', $variant) {
 			color: _oLabelsGet('text-color', $variant);
 		} @else {
 			color: oColorsGetTextColor(_oLabelsGet('background-color', $variant), 100);
-		}
-
-		// Set padding overrides if specified
-		@if _oLabelsGet('padding-vertical', $variant) and _oLabelsGet('padding-horizontal', $variant) {
-			padding: (_oLabelsGet('padding-vertical', $variant) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $variant) - _oLabelsGet('border-width'));
 		}
 	}
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -9,7 +9,7 @@
 				};
 				@include contains($selector: false) {
 					$expected-vertical-padding: oTypographySpacingSize(1) - 1px;
-					$expected-horizontal-padding: oTypographySpacingSize(2) - 1px;
+					$expected-horizontal-padding: oTypographySpacingSize(3) - 1px;
 					.o-labels {
 						padding: $expected-vertical-padding $expected-horizontal-padding;
 					}
@@ -27,24 +27,8 @@
 					};
 					@include contains($selector: false) {
 						$expected-vertical-padding: oTypographySpacingSize(2) - 1px;
-						$expected-horizontal-padding: oTypographySpacingSize(3) - 1px;
+						$expected-horizontal-padding: oTypographySpacingSize(4) - 1px;
 						.o-labels--big {
-							padding: $expected-vertical-padding $expected-horizontal-padding;
-						}
-					};
-				};
-			};
-		};
-		@include describe('with $size set to "small"') {
-			@include it('subtracts border width from the padding values') {
-				@include assert() {
-					@include output($selector: false) {
-						@include oLabelsSize('small');
-					};
-					@include contains($selector: false) {
-						$expected-vertical-padding: oTypographySpacingSize(1) - 1px;
-						$expected-horizontal-padding: oTypographySpacingSize(1) - 1px;
-						.o-labels--small {
 							padding: $expected-vertical-padding $expected-horizontal-padding;
 						}
 					};


### PR DESCRIPTION
This removes the small variant, as the standard size is now smaller. The
big variant is now around the same size as the previous standard size.

All labels are now transformed to uppercase.