### PR TITLE
Add a Pa11y demo

### DIFF
--- a/demos/src/data/pa11y.json
+++ b/demos/src/data/pa11y.json
@@ -1,0 +1,17 @@
+{
+	"states": [
+		null,
+		"content-commercial",
+		"content-premium",
+		"lifecycle-beta",
+		"support-active",
+		"support-dead",
+		"support-deprecated",
+		"support-experimental",
+		"support-maintained",
+		"tier-bronze",
+		"tier-gold",
+		"tier-platinum",
+		"tier-silver"
+	]
+}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -7,3 +7,7 @@ body {
 	@include oColorsFor('page', 'background');
 	margin: 1em;
 }
+
+.demo-container {
+	margin-bottom: 1em;
+}

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,0 +1,8 @@
+
+{{#states}}
+	<div class="demo-container">
+		<span class="o-labels o-labels--{{.}}">Testing</span>
+		<span class="o-labels o-labels--{{.}} o-labels--big">Testing</span>
+		<span class="o-labels o-labels--{{.}} o-labels--small">Testing</span>
+	</div>
+{{/states}}

--- a/origami.json
+++ b/origami.json
@@ -79,6 +79,13 @@
 			"title": "Typography",
 			"description": "Labels sitting in line with text that's styled with o-typography.",
 			"template": "/demos/src/typography.mustache"
+		},
+		{
+			"title": "Pa11y",
+			"name": "pa11y",
+			"template": "demos/src/pa11y.mustache",
+			"data": "demos/src/data/pa11y.json",
+			"hidden": true
 		}
 	]
 }


### PR DESCRIPTION
This currently doesn't test everything - I've done that manually. But
once OBT supports a11y testing for all brands this should just start
working.