### PR TITLE
Move to a more oTable way of doing mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The following states are used to represent the FT's service tiers:
 
 ### Sass
 
+#### Silent mode
+
 As with all Origami components, o-labels has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than incorporating its mixins into your own Sass) set `$o-labels-is-silent: false;` in your Sass before you import the o-labels Sass:
 
 ```sass
@@ -77,33 +79,41 @@ $o-labels-is-silent: false;
 @import 'o-labels/main';
 ```
 
-#### Using Sass mixins
+#### Mixin: `oLabels`
 
-The `oLabelsBase` mixin is used to output default label styles, including the `o-labels` class:
+If using o-labels in silent mode, you'll need to use the mixins outlined here to output styles.
+
+The `oLabels` mixin is used to output base styles as well as styles for _all_ of the label sizes and states. This output includes the `o-labels` classes:
 
 ```scss
-@include oLabelsBase;
+@include oLabels();
 ```
 
 ```css
 .o-labels {
     /* styles */
 }
-```
-
-The `oLabelsSize` mixin can be used to output a class for one of the label sizes. The valid sizes are `big` and `small`:
-
-```scss
-@include oLabelsSize('big');
-```
-
-```css
 .o-labels--big {
     /* styles */
 }
+/* etc. */
 ```
 
-The `oLabelsState` mixin can be used to output a class for one of the label states, outlined above in the [markup](#markup) documentation:
+If you wish to specify a subset of sizes and states to output styles for, you can pass in parameters (see [sizes](#sizes) and [states](#states) for available options):
+
+```scss
+@include oLabels(
+    $sizes: ('big'),
+    $states: (
+        'content-commercial',
+        'content-premium'
+    )
+);
+```
+
+#### Mixin: `oLabelsState`
+
+The `oLabelsState` mixin can be used to output a class for one of the label states, outlined in the [states table](#states):
 
 ```scss
 @include oLabelsState('content-commercial');
@@ -129,12 +139,40 @@ The `oLabelsState` mixin also accepts optional custom configurations, which over
 }
 ```
 
+#### Sizes
+
+This table outlines all of the possible sizes you can request in the [`oLabels` mixin](#mixin-olabels):
+
+| Size  | Description                                 | Brand support                |
+|-------|---------------------------------------------|------------------------------|
+| big   | Label with increased font size and padding. | master, internal, whitelabel |
+| small | Label with decreased font size and padding. | master, internal, whitelabel |
+
+#### States
+
+This table outlines all of the possible states you can request in the [`oLabels` mixin](#mixin-olabels) and [`oLabelsState` mixin](#mixin-olabelsstate):
+
+| Size                 | Description                                                   | Brand support |
+|----------------------|---------------------------------------------------------------|---------------|
+| content-commercial   | Used to identify paid posts or promoted content.              | master        |
+| content-premium      | Used to identify premium content.                             | master        |
+| lifecycle-beta       | Used to identify a feature that's in beta.                    | master        |
+| support-active       | Used to indicate that a component is actively maintained.     | internal      |
+| support-maintained   | Used to indicate that a component is maintained.              | internal      |
+| support-experimental | Used to indicate that a component is an experimental feature. | internal      |
+| support-deprecated   | Used to indicate that a component is deprecated.              | internal      |
+| support-dead         | Used to indicate that a component is no longer worked on.     | internal      |
+| tier-platinum        | Used to indicate a service with a platinum service tier.      | internal      |
+| tier-gold            | Used to indicate a service with a gold service tier.          | internal      |
+| tier-silver          | Used to indicate a service with a silver service tier.        | internal      |
+| tier-bronze          | Used to indicate a service with a bronze service tier.        | internal      |
+
 
 ## Migration guide
 
 ### How to upgrade from v3.x.x to v4.x.x?
 
-  - The `oLabels` mixin has been removed and most of the mixins have changed significantly. See the [Sass documentation](sass) for how to use the new and updated mixins
+  - The `oLabels` mixin parameters have been changed, and all of the  mixins have changed significantly. See the [Sass documentation](#sass) for how to use the new and updated mixins
   - The following states have been removed. The decision to remove was based on a search of the various codebases using o-labels, if you need one of the removed states then please contact us and we'll add it back:
     - `active`: This state has been removed entirely
     - `brand`: This state has been removed entirely

--- a/main.scss
+++ b/main.scss
@@ -8,24 +8,7 @@
 @import "src/scss/mixins";
 
 @if ($o-labels-is-silent == false) {
-
-	// Basic label styles
-	@include oLabelsBase;
-
-	// Label size variants
-	@if _oLabelsSupports('big') {
-		@include oLabelsSize('big');
-	}
-	@if _oLabelsSupports('small') {
-		@include oLabelsSize('small');
-	}
-
-	// Label state variants
-	@each $state in $_o-labels-states {
-		@if _oLabelsSupports($state) {
-			@include oLabelsState($state);
-		}
-	}
+	@include oLabels();
 
 	// Set module to silent again
 	$o-labels-is-silent: true !global;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,9 +1,41 @@
 
+/// Outputs all available features and styles for labels.
+///
+/// @param {List} $sizes - The label size variants to output styles for.
+/// @param {List} $states - The label state variants to output styles for.
+/// @output The output includes the `.o-labels` class definition as well as class definitions for every variant.
+/// @example scss - All label styles
+///   @include oLabels();
+/// @example scss - Base styles, big size variant, and gold tier state variant
+///   @include oLabels(('big'), ('tier-gold'));
+/// @access public
+@mixin oLabels($sizes: $_o-labels-sizes, $states: $_o-labels-states) {
+
+	// Base label styles
+	@include _oLabelsBase();
+
+	// Label size variants
+	@each $size in $_o-labels-sizes {
+		@if index($sizes, $size) and _oLabelsSupports($size) {
+			@include _oLabelsSize($size);
+		}
+	}
+
+	// Label state variants
+	@each $state in $_o-labels-states {
+		@if index($states, $state) and _oLabelsSupports($state) {
+			@include oLabelsState($state);
+		}
+	}
+}
+
 /// Base styles for labels.
+///
 /// @output The output includes the `.o-labels` class definition and all styles for a basic label.
 /// @example scss - Base label styles
-///   @include oLabelsBase();
-@mixin oLabelsBase() {
+///   @include _oLabelsBase();
+/// @access private
+@mixin _oLabelsBase() {
 	.o-labels {
 		@include oTypographySans($scale: _oLabelsGet('font-scale'), $line-height: 1em);
 		font-weight: 500;
@@ -21,11 +53,13 @@
 }
 
 /// Size modifiers for labels.
+///
 /// @param {String} $size - The label size to output styles for. The valid sizes are `big` and `small`.
 /// @output The output includes the `.o-labels--SIZE` modifier class definition, which includes all overrides.
 /// @example scss - Big label styles
-///   @include oLabelsSize('big');
-@mixin oLabelsSize($size) {
+///   @include _oLabelsSize('big');
+/// @access private
+@mixin _oLabelsSize($size) {
 	.o-labels--#{$size} {
 		// We use the scale and set font size manually to rely on the cascade rather
 		// than repeating the font family and line height from the main label class
@@ -38,6 +72,7 @@
 }
 
 /// State modifiers for labels.
+///
 /// @param {String|Map} $state-name - The label state to output styles for. See README for available states.
 /// @param {Map} $variant [null] - A brand variant configuration which can be used to create custom label states. See README for more examples.
 /// @output The output includes the `.o-labels--STATE` modifier class definition, which includes all overrides.
@@ -47,6 +82,7 @@
 ///   @include oLabelsState('citrus-fruit', (
 ///       background-color: oColorsGetPaletteColor('lemon')
 ///   ));
+/// @access public
 @mixin oLabelsState($state-name, $variant: null) {
 
 	// If we have a custom config, we use that instead of one of the

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,13 +3,26 @@
 /// Set to false to output default label classes
 ///
 /// @type Boolean
+/// @access public
 $o-labels-is-silent: true !default;
+
+/// Label sizes
+/// A list used to loop over all label sizes.
+/// For actual values: (@see _brand.scss).
+///
+/// @type List
+/// @access private
+$_o-labels-sizes: (
+	'big',
+	'small'
+);
 
 /// Label states
 /// A list used to loop over all label states.
 /// For actual values: (@see _brand.scss).
 ///
 /// @type List
+/// @access private
 $_o-labels-states: (
 	'content-commercial',
 	'content-premium',

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,11 +1,11 @@
 
 @include describe('oLabels mixins') {
 
-	@include describe('oLabelsBase') {
+	@include describe('_oLabelsBase') {
 		@include it('subtracts border width from the padding values') {
 			@include assert() {
 				@include output($selector: false) {
-					@include oLabelsBase;
+					@include _oLabelsBase;
 				};
 				@include contains($selector: false) {
 					$expected-vertical-padding: oTypographySpacingSize(1) - 1px;
@@ -18,12 +18,12 @@
 		};
 	};
 
-	@include describe('oLabelsSize') {
+	@include describe('_oLabelsSize') {
 		@include describe('with $size set to "big"') {
 			@include it('subtracts border width from the padding values') {
 				@include assert() {
 					@include output($selector: false) {
-						@include oLabelsSize('big');
+						@include _oLabelsSize('big');
 					};
 					@include contains($selector: false) {
 						$expected-vertical-padding: oTypographySpacingSize(2) - 1px;


### PR DESCRIPTION
We now have a single oLabels mixin which outputs everything, similar to
the main oTable mixin.