### PR TITLE
[WIP] Make the small variant a little smaller

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -24,8 +24,8 @@ $_o-labels-shared-brand-config: (
 	),
 	'small': (
 		font-scale: -2,
-		padding-vertical: oTypographySpacingSize(1),
-		padding-horizontal: oTypographySpacingSize(2)
+		padding-vertical: 2px,
+		padding-horizontal: 4px
 	)
 );
 

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -37,5 +37,24 @@
 		};
 	};
 
+	@include describe('_oLabelsSize') {
+		@include describe('with $size set to "small"') {
+			@include it('subtracts border width from the padding values') {
+				@include assert() {
+					@include output($selector: false) {
+						@include _oLabelsSize('small');
+					};
+					@include contains($selector: false) {
+						$expected-vertical-padding: 1px;
+						$expected-horizontal-padding: 3px;
+						.o-labels--small {
+							padding: $expected-vertical-padding $expected-horizontal-padding;
+						}
+					};
+				};
+			};
+		};
+	};
+
 
 };


### PR DESCRIPTION
This is to address issues with the small label when lots are displayed
on the same page, e.g. in MyFT. The new padding more closely matches the
original label padding and so fits nicely with the existing designs.

<table>
<thead>
<tr>
<th>Current</th>
<th>New</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://user-images.githubusercontent.com/138944/48074614-38173d00-e1d9-11e8-965a-7b4133e32f2a.png" alt="Old labels in MyFT page"/></td>
<td><img src="https://user-images.githubusercontent.com/138944/48341181-557a5a00-e664-11e8-9931-b913a60ae102.png" alt="New labels in MyFT page"/></td>
</tr>
</tbody>
</table>
