### PR TITLE
Remove default capitalisation

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -15,12 +15,12 @@
 $_o-labels-shared-brand-config: (
 	font-scale: -1,
 	padding-vertical: oTypographySpacingSize(1),
-	padding-horizontal: oTypographySpacingSize(3),
+	padding-horizontal: oTypographySpacingSize(2),
 	border-width: 1px,
 	'big': (
 		font-scale: 0,
 		padding-vertical: oTypographySpacingSize(2),
-		padding-horizontal: oTypographySpacingSize(4)
+		padding-horizontal: oTypographySpacingSize(2)
 	),
 	'small': (
 		font-scale: -2,
@@ -44,7 +44,10 @@ $_o-labels-shared-brand-config: (
 			'lifecycle-beta': (
 				background-color: oColorsGetPaletteColor('paper'),
 				border-color: oColorsGetPaletteColor('black-20'),
-				text-color: oColorsGetPaletteColor('black-80')
+				text-color: oColorsGetPaletteColor('black-80'),
+				text-transform: uppercase,
+				padding-vertical: oTypographySpacingSize(1),
+				padding-horizontal: oTypographySpacingSize(3),
 			)
 		)),
 		'supports-variants': (

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -44,7 +44,6 @@
 		box-sizing: border-box;
 		margin: 0;
 		text-decoration: none;
-		text-transform: uppercase;
 		padding: (_oLabelsGet('padding-vertical') - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal') - _oLabelsGet('border-width'));
 		color: _oLabelsGet('text-color');
 		background-color: _oLabelsGet('background-color');
@@ -92,12 +91,18 @@
 	.o-labels--#{$state-name} {
 		background-color: _oLabelsGet('background-color', $variant);
 		border-color: _oLabelsGet('border-color', $variant);
+		text-transform: _oLabelsGet('text-transform', $variant);
 
 		// Set text colour or calculate based on background
 		@if _oLabelsGet('text-color', $variant) {
 			color: _oLabelsGet('text-color', $variant);
 		} @else {
 			color: oColorsGetTextColor(_oLabelsGet('background-color', $variant), 100);
+		}
+
+		// Set the spacing
+		@if _oLabelsGet('padding-vertical', $variant) and _oLabelsGet('padding-horizontal', $variant) {
+			padding: (_oLabelsGet('padding-vertical', $variant) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $variant) - _oLabelsGet('border-width'));
 		}
 	}
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -9,7 +9,7 @@
 				};
 				@include contains($selector: false) {
 					$expected-vertical-padding: oTypographySpacingSize(1) - 1px;
-					$expected-horizontal-padding: oTypographySpacingSize(3) - 1px;
+					$expected-horizontal-padding: oTypographySpacingSize(2) - 1px;
 					.o-labels {
 						padding: $expected-vertical-padding $expected-horizontal-padding;
 					}
@@ -27,7 +27,7 @@
 					};
 					@include contains($selector: false) {
 						$expected-vertical-padding: oTypographySpacingSize(2) - 1px;
-						$expected-horizontal-padding: oTypographySpacingSize(4) - 1px;
+						$expected-horizontal-padding: oTypographySpacingSize(2) - 1px;
 						.o-labels--big {
 							padding: $expected-vertical-padding $expected-horizontal-padding;
 						}


### PR DESCRIPTION
The only label that's now capitalised is the beta label, the rest are
lowercase at the moment. We may add capitalisation as a variant later if
there are compelling use-cases for it.