### PR TITLE
Correct mixin usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ If you wish to specify a subset of sizes and states to output styles for, you ca
 
 ```scss
 @include oLabels($opts: (
-    sizes: ('big'),
-    states: (
+    'sizes': ('big'),
+    'states': (
         'content-commercial',
         'content-premium'
     )

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ If you wish to specify a subset of sizes and states to output styles for, you ca
 
 ```scss
 @include oLabels($opts: (
-    $sizes: ('big'),
-    $states: (
+    sizes: ('big'),
+    states: (
         'content-commercial',
         'content-premium'
     )


### PR DESCRIPTION
I tried the example and got SASS compile errors as `$sizes` was undefined.

I think this is the correct syntax?