### PR TITLE
Add a content mixin `oLabelsContent`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,31 @@ The `oLabelsAddState` mixin also accepts optional custom configurations, which o
 }
 ```
 
+#### Mixin: `oLabelsContent`
+
+When it's not possible to use an `o-loading` CSS class, for example within another Origami component, use `oLabelsContent` to output a label with a custom class.
+
+If it is possible to use `o-loading` classes we recommend [oLabels](#mixin-olabels) and [oLabelsAddStates](#mixin-olabelsaddstate) instead. Using these will help reduce the size of your CSS bundle where mutliple labels are used.
+
+To output an existing label:
+```scss
+.o-example-my-label {
+	@include oLabelsContent($opts: ('size': 'big', 'state': 'tier-gold'));
+}
+```
+
+To output a custom label:
+```scss
+.o-example-my-custom-label {
+	@include oLabelsContent($opts: (
+		'size': 'big',
+		'state': (
+			'background-color': oColorsGetPaletteColor('lemon')
+		)
+	));
+}
+```
+
 #### Sizes
 
 This table outlines all of the possible sizes you can request in the [`oLabels` mixin](#mixin-olabels):

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -30,13 +30,7 @@
 /// @access private
 @mixin _oLabelsSize($size) {
 	.o-labels--#{$size} {
-		// We use the scale and set font size manually to rely on the cascade rather
-		// than repeating the font family and line height from the main label class
-		@if _oLabelsGet('font-scale', $size) {
-			// TODO is there a nicer way to get this number?
-			font-size: nth(oTypographyGetScale(_oLabelsGet('font-scale', $size)), 1) * 1px;
-		}
-		padding: (_oLabelsGet('padding-vertical', $size) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $size) - _oLabelsGet('border-width'));
+		@include _oLabelsSizeContent($size);
 	}
 }
 
@@ -59,20 +53,71 @@
 	$variant: if($opts, $opts, $state-name);
 
 	.o-labels--#{$state-name} {
-		background-color: _oLabelsGet('background-color', $variant);
-		border-color: _oLabelsGet('border-color', $variant);
-		text-transform: _oLabelsGet('text-transform', $variant);
+		@include _oLabelsStateContent($variant);
+	}
+}
 
-		// Set text colour or calculate based on background
-		@if _oLabelsGet('text-color', $variant) {
-			color: _oLabelsGet('text-color', $variant);
-		} @else {
-			color: oColorsGetTextColor(_oLabelsGet('background-color', $variant), 100);
-		}
+/// Styles for a label without an `o-loading` CSS class.
+/// Recommended only when a custom class name is required, for example within another component.
+/// @output Styles for a label without a CSS selector.
+/// @param {Map} $opts - A map containing the label size and state (a state name or custom state map).
+/// @example An existing label.
+/// 	.o-example-my-label {
+/// 		@include oLabelsContent($opts: ('size': 'big', 'state': 'tier-gold'));
+/// 	}
+/// @example A custom label.
+/// 	.o-example-my-custom-label {
+/// 		@include oLabelsContent($opts: (
+/// 			'size': 'big',
+/// 			'state': (
+/// 				'background-color': oColorsGetPaletteColor('lemon')
+/// 			)
+/// 		));
+/// 	}
+/// @access public
+@mixin oLabelsContent($opts: ()) {
+	$size: map-get($opts, 'size');
+	$state: map-get($opts, 'state');
 
-		// Set the spacing
-		@if _oLabelsGet('padding-vertical', $variant) and _oLabelsGet('padding-horizontal', $variant) {
-			padding: (_oLabelsGet('padding-vertical', $variant) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $variant) - _oLabelsGet('border-width'));
+	@if $state {
+		@include _oLabelsStateContent($state);
+	}
+
+	@if $size {
+		@include _oLabelsSizeContent($size);
+	}
+}
+
+/// Styles to change the size of the label.
+/// @param {Sting} $size - The label size to output styles for. The valid sizes are `big` and `small`.
+/// @access private
+@mixin _oLabelsSizeContent($size) {
+		// We use the scale and set font size manually to rely on the cascade rather
+		// than repeating the font family and line height from the main label class
+		@if _oLabelsGet('font-scale', $size) {
+			// TODO is there a nicer way to get this number?
+			font-size: nth(oTypographyGetScale(_oLabelsGet('font-scale', $size)), 1) * 1px;
 		}
+		padding: (_oLabelsGet('padding-vertical', $size) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $size) - _oLabelsGet('border-width'));
+}
+
+/// Styles for a state.
+/// @param {Sting|Map} $variant - An existing state name or a custom state map.
+/// @access private
+@mixin _oLabelsStateContent($variant) {
+	background-color: _oLabelsGet('background-color', $variant);
+	border-color: _oLabelsGet('border-color', $variant);
+	text-transform: _oLabelsGet('text-transform', $variant);
+
+	// Set text colour or calculate based on background
+	@if _oLabelsGet('text-color', $variant) {
+		color: _oLabelsGet('text-color', $variant);
+	} @else {
+		color: oColorsGetTextColor(_oLabelsGet('background-color', $variant), 100);
+	}
+
+	// Set the spacing
+	@if _oLabelsGet('padding-vertical', $variant) and _oLabelsGet('padding-horizontal', $variant) {
+		padding: (_oLabelsGet('padding-vertical', $variant) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $variant) - _oLabelsGet('border-width'));
 	}
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -56,5 +56,80 @@
 		};
 	};
 
+	@include describe('oLabelsContent') {
+		@include describe('with "size" and no "state"') {
+			@include it('outputs label dimentions only') {
+				@include assert() {
+					@include output() {
+						.o-example-label {
+							@include oLabelsContent($opts: ('size': 'small'));
+						}
+					};
+					@include expect() {
+						.o-example-label {
+    						font-size: 12px;
+    						padding: 1px 3px;
+						}
+					};
+				};
+			};
+		};
+		@include describe('with "state" and no "size"') {
+			@include it('outputs state styles only') {
+				@include assert() {
+					@include output() {
+						.o-example-label {
+							@include oLabelsContent($opts: ('state': 'content-commercial'));
+						}
+					};
+					@include expect() {
+						.o-example-label {
+    						background-color: #008040;
+    						color: white;
+						}
+					};
+				};
+			};
+		};
+		@include describe('with a custom "state" and no "size"') {
+			@include it('outputs custom state styles only') {
+				@include assert() {
+					@include output() {
+						.o-example-label {
+							@include oLabelsContent($opts: ('state': (
+								'background-color': hotpink
+							)));
+						}
+					};
+					@include expect() {
+						.o-example-label {
+    						background-color: hotpink;
+    						color: black;
+						}
+					};
+				};
+			};
+		};
+		@include describe('with "state" and "size"') {
+			@include it('outputs state and size styles') {
+				@include assert() {
+					@include output() {
+						.o-example-label {
+							@include oLabelsContent($opts: ('size': 'small', 'state': 'content-commercial'));
+						}
+					};
+					@include expect() {
+						.o-example-label {
+    						background-color: #008040;
+    						color: white;
+    						font-size: 12px;
+    						padding: 1px 3px;
+						}
+					};
+				};
+			};
+		};
+	};
+
 
 };


### PR DESCRIPTION
Since discouraging custom classes in projects, we've started adding "content" mixins so we can still use custom classes within other Origami components. E.g. https://github.com/Financial-Times/o-loading#sass