### PR TITLE
Upgrade dependencies to the latest beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The `oLabelsAddState` mixin also accepts optional custom configurations, which o
 
 ```scss
 @include oLabelsAddState('citrus-fruit', (
-    background-color: oColorsGetPaletteColor('lemon')
+    background-color: oColorsByName('lemon')
 ));
 ```
 
@@ -165,7 +165,7 @@ To output a custom label:
 		'base': true,
 		'size': 'big',
 		'state': (
-			'background-color': oColorsGetPaletteColor('lemon')
+			'background-color': oColorsByName('lemon')
 		)
 	));
 }

--- a/bower.json
+++ b/bower.json
@@ -4,8 +4,8 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-colors": "^4.7.2",
-    "o-typography": "^5.7.7",
+    "o-colors": "5.0.0-beta.3",
+    "o-typography": "6.0.0-beta.4",
     "o-brand": "^3.1.1",
     "o-spacing": "^2.0.0"
   }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -4,7 +4,7 @@ $o-labels-is-silent: false;
 @import "../../main";
 
 body {
-	@include oColorsFor('page', 'background');
+	background: oColorsByUsecase('page', 'background');
 
 	// Important used to ensure that this overrides the `body` specificity
 	// provided by the build service

--- a/main.scss
+++ b/main.scss
@@ -3,6 +3,7 @@
 @import "o-colors/main";
 @import "o-typography/main";
 
+@import "src/scss/colors";
 @import "src/scss/brand";
 @import "src/scss/variables";
 @import "src/scss/mixins";

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -33,18 +33,18 @@ $_o-labels-shared-brand-config: (
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-labels', 'master', (
 		'variables': map-merge($_o-labels-shared-brand-config, (
-			text-color: oColorsGetPaletteColor('black'),
-			background-color: oColorsGetPaletteColor('wheat'),
+			text-color: oColorsByName('black'),
+			background-color: oColorsByName('wheat'),
 			'content-commercial': (
-				background-color: oColorsGetTint('jade', 50)
+				background-color: oColorsByName('o-labels/commercial-content')
 			),
 			'content-premium': (
-				background-color: oColorsGetPaletteColor('black')
+				background-color: oColorsByName('black')
 			),
 			'lifecycle-beta': (
-				background-color: oColorsGetPaletteColor('paper'),
-				border-color: oColorsGetPaletteColor('black-20'),
-				text-color: oColorsGetPaletteColor('black-80'),
+				background-color: oColorsByName('paper'),
+				border-color: oColorsByName('black-20'),
+				text-color: oColorsByName('black-80'),
 				text-transform: uppercase,
 				padding-vertical: oSpacingByName('s1'),
 				padding-horizontal: oSpacingByName('s3'),
@@ -69,13 +69,13 @@ $_o-labels-shared-brand-config: (
 				background-color: oColorsMix('jade', 'black', 70)
 			),
 			'support-dead': (
-				background-color: oColorsGetPaletteColor('black')
+				background-color: oColorsByName('black')
 			),
 			'support-deprecated': (
-				background-color: oColorsGetPaletteColor('crimson')
+				background-color: oColorsByName('crimson')
 			),
 			'support-experimental': (
-				background-color: oColorsGetPaletteColor('lemon')
+				background-color: oColorsByName('lemon')
 			),
 			'support-maintained': (
 				background-color: oColorsMix('jade', 'black', 70)

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,0 +1,5 @@
+// Set commercial content colour. The precise jade mix maintains the same colour
+// as was previously generated with an o-colors tone.
+@if oBrandGetCurrentBrand() == 'master' {
+    @include oColorsSetColor('o-labels/commercial-content', oColorsMix('jade', 'black', $percentage: 83.334));
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -41,7 +41,7 @@
 ///   @include oLabelsAddState('tier-gold');
 /// @example scss - Custom label state
 ///   @include oLabelsAddState('citrus-fruit', (
-///       background-color: oColorsGetPaletteColor('lemon')
+///       background-color: oColorsByName('lemon')
 ///   ));
 /// @access public
 @mixin oLabelsAddState($state-name, $opts: null) {
@@ -69,7 +69,7 @@
 /// 			'base': true,
 /// 			'size': 'big',
 /// 			'state': (
-/// 				'background-color': oColorsGetPaletteColor('lemon')
+/// 				'background-color': oColorsByName('lemon')
 /// 			)
 /// 		));
 /// 	}
@@ -96,11 +96,9 @@
 /// @param {Sting} $size - The label size to output styles for. The valid sizes are `big` and `small`.
 /// @access private
 @mixin _oLabelsSizeContent($size) {
-		// We use the scale and set font size manually to rely on the cascade rather
-		// than repeating the font family and line height from the main label class
-		@if _oLabelsGet('font-scale', $size) {
-			// TODO is there a nicer way to get this number?
-			font-size: nth(oTypographyGetScale(_oLabelsGet('font-scale', $size)), 1) * 1px;
+		$scale: _oLabelsGet('font-scale', $size);
+		@if $scale {
+			@include oTypographySans($scale, $line-height: 1, $include-font-family: false);
 		}
 		padding: (_oLabelsGet('padding-vertical', $size) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $size) - _oLabelsGet('border-width'));
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -58,15 +58,19 @@
 		@include describe('with "size" and no "state"') {
 			@include it('outputs label dimentions only') {
 				@include assert() {
-					@include output() {
+					@include output($selector: false) {
 						.o-example-label {
 							@include oLabelsContent($opts: ('size': 'small'));
 						}
 					};
-					@include expect() {
+					@include expect($selector: false) {
 						.o-example-label {
-    						font-size: 12px;
+							font-size: 12px;
+							line-height: 1;
     						padding: 1px 3px;
+						}
+						.o-typography--loading-sans .o-example-label {
+						  font-size: 10.44px;
 						}
 					};
 				};
@@ -111,17 +115,22 @@
 		@include describe('with "state" and "size"') {
 			@include it('outputs state and size styles') {
 				@include assert() {
-					@include output() {
+					@include output($selector: false) {
 						.o-example-label {
 							@include oLabelsContent($opts: ('size': 'small', 'state': 'content-commercial'));
 						}
 					};
-					@include expect() {
+					@include expect($selector: false) {
 						.o-example-label {
     						background-color: #008040;
     						color: white;
-    						font-size: 12px;
+							font-size: 12px;
+							line-height: 1;
     						padding: 1px 3px;
+						}
+
+						.o-typography--loading-sans .o-example-label {
+							font-size: 10.44px;
 						}
 					};
 				};


### PR DESCRIPTION
o-colors removed support for jade toning. The commercial content
colour uses a jade tone but we may fortunately replace with a mix,
to avoid communicating a slight colour change. 

The commercial content colour has been set to the palette so o-teaser 
may share it. Currently they both define the commercial content colour 
independently.

The new version of o-typography consistently includes the progressive
font fallback, which is now represented in o-labels tests.