### PR TITLE
Swap label weight medium (500) for semibold.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -6,8 +6,11 @@
 ///   @include _oLabelsBaseContent();
 /// @access private
 @mixin _oLabelsBaseContent() {
-	@include oTypographySans($scale: _oLabelsGet('font-scale'), $line-height: 1em);
-	font-weight: 500;
+	@include oTypographySans(
+		$scale: _oLabelsGet('font-scale'),
+		$weight: 'regular',
+		$line-height: 1em
+	);
 	text-align: center;
 	display: inline-block;
 	box-sizing: border-box;


### PR DESCRIPTION
This font weight is rarely used, usually by mistake, and is going
to be removed from ft.com

https://github.com/Financial-Times/o-labels/issues/60