### PR TITLE
Correct "Swap label weight medium (500) for semibold."

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -8,7 +8,7 @@
 @mixin _oLabelsBaseContent() {
 	@include oTypographySans(
 		$scale: _oLabelsGet('font-scale'),
-		$weight: 'regular',
+		$weight: 'semibold',
 		$line-height: 1em
 	);
 	text-align: center;


### PR DESCRIPTION
The previous commit swapped weight "medium" for "regular". It should
have swapped for "semibold", as the commit message states.

"Two steps forward, one step back"