### PR TITLE
Add indictor and timestamp labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,45 @@
 
 Labels for content classification or to emphasise a value.
 
+- [Label Types](#label-types)
 - [Markup](#markup)
 - [Sass](#sass)
 - [Migration guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
+## Label Types
+
+There are three types of label:
+- A standard label, the default.
+- An indicator label.
+- A timestamp label.
+
+### Standard Label
+
+The standard label is used for content classification or to emphasise a value. For example to highlight commercial or premium content for the master brand, or to highlight a service tier in internal products. Custom labels may be created.
+
+### Indicator Label
+
+The indicator label is used to show article status with new, updated, and live variants. The indicator label only supports the master brand but [internal brand support is under consideration](https://github.com/Financial-Times/o-labels/issues/58).
+
+### Timestamp Label
+
+The timestamp label is used to show article status in place of an indicator label when the article is not new, updated, or live. The timestamp label only supports the master brand.
+
 ## Markup
 
-The most minimal markup for a label is as follows:
+### Standard Label Markup
+
+The most minimal markup for a standard label is as follows:
 
 ```html
 <span class="o-labels">Label</span>
 ```
 
-Labels are displayed inline so including the above markup in a paragraph, for example, will make it sit alongside the text.
+Standard labels are displayed inline so including the above markup in a paragraph, for example, will make it sit alongside the text.
 
-There are several size modifier classes which can be used to change the general appearance of a label:
+There are several size modifier classes which can be used to change the general appearance of a standard label:
 
 ```html
 <span class="o-labels o-labels--big">Big Label</span>
@@ -27,9 +49,7 @@ There are several size modifier classes which can be used to change the general 
 
 Labels can also have one of several states. The available states depend on which brand you are using (there are no states for whitelabel branded components):
 
-### Masterbrand
-
-The following states are used to categorise content, mostly on FT.com:
+The following master brand states are used to categorise content, mostly on FT.com:
 
 ```html
 <span class="o-labels o-labels--content-commercial">Paid Post</span> (used for paid post and promoted content)
@@ -42,9 +62,7 @@ The following state is used to indicate that a feature is in a beta state:
 <span class="o-labels o-labels--lifecycle-beta">Beta</span>
 ```
 
-### Internal
-
-The following states are used to represent the different support levels of Origami components:
+The following internal brand states are used to represent the different support levels of Origami components:
 
 ```html
 <span class="o-labels o-labels--support-active">Active</span>
@@ -54,7 +72,7 @@ The following states are used to represent the different support levels of Origa
 <span class="o-labels o-labels--support-dead">Dead</span>
 ```
 
-The following states are used to represent the FT's service tiers:
+The following internal brand states are used to represent the FT's service tiers:
 
 ```html
 <span class="o-labels o-labels--support-platinum">Platinum</span>
@@ -62,6 +80,59 @@ The following states are used to represent the FT's service tiers:
 <span class="o-labels o-labels--support-silver">Silver</span>
 <span class="o-labels o-labels--support-bronze">Bronze</span>
 ```
+
+### Indicator Label Markup
+
+Indicator labels have one of three statuses:
+- `live`
+- `updated`
+- `new`
+
+Use the following markup for a live label:
+```html
+<span class="o-labels-indicator o-labels-indicator--live">
+    <span class="o-labels-indicator__status">
+		live
+    </span>
+</span>
+```
+
+For an updated or new label, use the associated modifier class, e.g. `o-labels-indicator--updated`, and add a child element `o-labels-indicator__timestamp` to show the new/updated time. We recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
+
+```html
+<span class="o-labels-indicator o-labels-indicator--new">
+    <span class="o-labels-indicator__status">
+        new
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo `time` element only (the datetime is not 1 hour ago) -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+```
+
+Indicator labels also support an inverse theme for use on dark backgrounds. To use an inverse theme add the `o-labels-indicator--inverse` class to your markup.
+```diff
+-<span class="o-labels-indicator o-labels-indicator--live">
++<span class="o-labels-indicator o-labels-indicator--live o-labels-indicator--inverse">
+    <span class="o-labels-indicator__status">
+		live
+    </span>
+</span>
+```
+
+## Timestamp Markup
+
+To include a timestamp label use the following markup. Note the timestamp label also supports an optional inverse variant for dark background with the `o-labels-timestamp--inverse` class:
+
+```html
+<time class="o-labels-timestamp o-labels-timestamp--inverse">
+    <!-- demo `time` element only -->
+    <time datetime="2016-02-29T12:35:48Z" title="February 29 2016 12:35 pm" aria-label="February 29 2016">February 29 2016</time>
+</time>
+```
+
+As with the indicator label, we recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
 
 ## Sass
 
@@ -125,7 +196,9 @@ The `oLabelsAddState` mixin also accepts optional custom configurations, which o
 
 ### Mixin: `oLabelsContent`
 
-When it's not possible to use an `o-labels` CSS class, for example within another Origami component, use `oLabelsContent` to output a label with a custom class.
+When it's not possible to use an `o-labels` CSS class, for example within another Origami component, use `oLabelsContent` to output a standard label with a custom class.
+
+_For an indicator label see `oLabelsIndicatorContent`, and for a timestamp label see `oLabelsTimestampContent`._
 
 If it is possible to use `o-labels` classes we recommend [oLabels](#mixin-olabels) and [oLabelsAddStates](#mixin-olabelsaddstate) instead. Using these will help reduce the size of your CSS bundle where mutliple labels are used.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This table outlines the possible indicator label statuses:
 | Size                 | Description                                                   | Brand support |
 |----------------------|---------------------------------------------------------------|---------------|
 | live                 | Indicate a story is live.                                     | master        |
-| live                 | Indicate a live story is no longer live.                                     | master        |
+| closed               | Indicate a live story is no longer live.                      | master        |
 | new                  | Indicate a story is new.                                      | master        |
 | updated              | Indicate a story has been updated.                            | master        |
 
@@ -137,8 +137,16 @@ Use the following markup for a live label:
 </span>
 ```
 
-For a closed, updated, or new label, use the associated modifier class, e.g. `o-labels-indicator--updated`, and add a child element `o-labels-indicator__timestamp` to show the new/updated time. We recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
+Use the modifier class `o-labels-indicator--closed` for a closed label:
+```html
+<span class="o-labels-indicator o-labels-indicator--closed">
+    <span class="o-labels-indicator__status">
+		closed
+    </span>
+</span>
+```
 
+For an updated or new label use the associated modifier class, e.g. `o-labels-indicator--updated`, and add a child element `o-labels-indicator__timestamp` to show the new/updated time. We recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
 ```html
 <span class="o-labels-indicator o-labels-indicator--new">
     <span class="o-labels-indicator__status">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-labels
 
-Labels for content classification or to emphasise a value.
+Labels for content classification, to emphasise a value, or highlight a status.
 
 - [Label Types](#label-types)
 - [Markup](#markup)
@@ -20,9 +20,47 @@ There are three types of label:
 
 The standard label is used for content classification or to emphasise a value. For example to highlight commercial or premium content for the master brand, or to highlight a service tier in internal products. Custom labels may be created.
 
+#### Standard Label Sizes
+
+This table outlines the possible standard label sizes.
+
+| Size  | Description                                 | Brand support                |
+|-------|---------------------------------------------|------------------------------|
+| big   | Label with increased font size and padding. | master, internal, whitelabel |
+| small | Label with decreased font size and padding. | master, internal, whitelabel |
+
+#### Standard Label States
+
+This table outlines the possible standard label states. Custom states may also be created.
+
+| Size                 | Description                                                   | Brand support |
+|----------------------|---------------------------------------------------------------|---------------|
+| content-commercial   | Used to identify paid posts or promoted content.              | master        |
+| content-premium      | Used to identify premium content.                             | master        |
+| lifecycle-beta       | Used to identify a feature that's in beta.                    | master        |
+| support-active       | Used to indicate that a component is actively maintained.     | internal      |
+| support-maintained   | Used to indicate that a component is maintained.              | internal      |
+| support-experimental | Used to indicate that a component is an experimental feature. | internal      |
+| support-deprecated   | Used to indicate that a component is deprecated.              | internal      |
+| support-dead         | Used to indicate that a component is no longer worked on.     | internal      |
+| tier-platinum        | Used to indicate a service with a platinum service tier.      | internal      |
+| tier-gold            | Used to indicate a service with a gold service tier.          | internal      |
+| tier-silver          | Used to indicate a service with a silver service tier.        | internal      |
+| tier-bronze          | Used to indicate a service with a bronze service tier.        | internal      |
+
 ### Indicator Label
 
-The indicator label is used to show article status with new, updated, and live variants. The indicator label only supports the master brand but [internal brand support is under consideration](https://github.com/Financial-Times/o-labels/issues/58).
+The indicator label is used to show story status with new, updated, and live variants. The indicator label only supports the master brand but [internal brand support is under consideration](https://github.com/Financial-Times/o-labels/issues/58).
+
+#### Indicator Label Status
+
+This table outlines the possible indicator label statuses:
+
+| Size                 | Description                                                   | Brand support |
+|----------------------|---------------------------------------------------------------|---------------|
+| live                 | Indicate a story is live.                                     | master        |
+| new                  | Indicate a story is new.                                      | master        |
+| updated              | Indicate a story has been updated.                            | master        |
 
 ### Timestamp Label
 
@@ -136,71 +174,74 @@ As with the indicator label, we recommend using [o-date](https://registry.origam
 
 ## Sass
 
-### Mixin: `oLabels`
-
-The `oLabels` mixin is used to output base styles as well as styles for _all_ of the label sizes and states. This output includes the `o-labels` classes:
+Output all label styles with the `oLabels` mixin:
 
 ```scss
 @include oLabels();
 ```
 
-```css
-.o-labels {
-	/* styles */
-}
-.o-labels--big {
-	/* styles */
-}
-/* etc. */
-```
+Or pass an options map `$opts` argument to output just the label styles you need. Options include:
 
-If you wish to specify a subset of sizes and states to output styles for, you can pass in options (see [sizes](#sizes) and [states](#states) for available options):
+- sizes: a list of standard label sizes to output (see [available sizes](#standard-label-sizes))
+- states: a list of standard label states to output (see [available states](#standard-label-states)))
+- indicators
+	- status: a list of indicator label statuses to output (see [available statuses](#indicator-label-status))
+	- inverse
+- timestamp
+	- inverse
 
 ```scss
 @include oLabels($opts: (
+	// standard label sizes to output
+	// e.g. .o-labels--big
 	'sizes': ('big'),
+	// standard label states to output
+	// e.g. .o-labels--content-commercial
 	'states': (
 		'content-commercial',
 		'content-premium'
+	),
+	// indicator label labels to output
+	// .o-labels-indicator
+	'indicators': (
+		// indicator label statuses to output
+		// .o-labels-indicator--live
+		'status': ('live'),
+		// whether to output the indicator label inverse style
+		// .o-labels-indicator--inverse
+		'inverse': true,
+	),
+	// output the timestamp label label
+	// .o-labels-timestamp
+	'timestamp': (
+		// whether to output the timestamp label inverse style
+		// .o-labels-timestamp--inverse
+		'inverse': true
 	)
 ));
 ```
 
-### Mixin: `oLabelsAddState`
+### Custom Standard Label State
 
-The `oLabelsAddState` mixin can be used to output a class for one of the label states, outlined in the [states table](#states):
-
-```scss
-@include oLabelsAddState('content-commercial');
-```
-
-```css
-.o-labels--content-commercial {
-	/* styles */
-}
-```
-
-The `oLabelsAddState` mixin also accepts optional custom configurations, which override defaults or allow you to define your own label states:
+Use `oLabelsAddState` mixin to add a custom label state for the standard label. See the [`oLabelsAddState` SassDoc](https://registry.origami.ft.com/components/o-labels/sassdoc?brand=master#mixin-olabelsaddstate) for more details.
 
 ```scss
+// outputs a class .o-labels--citrus-fruit
 @include oLabelsAddState('citrus-fruit', (
 	background-color: oColorsByName('lemon')
 ));
 ```
 
-```css
-.o-labels--citrus-fruit {
-	/* styles */
-}
-```
+### Custom Markup
 
-### Mixin: `oLabelsContent`
+When it's not possible to use an `o-labels` CSS class, for example within another Origami component, use:
+- `oLabelsContent` to output a standard label with a custom class.
+- `oLabelsIndicatorContent` to output an indicator label with a custom class.
+- `oLabelsTimestampContent` to output a timestamp label with a custom class.
 
-When it's not possible to use an `o-labels` CSS class, for example within another Origami component, use `oLabelsContent` to output a standard label with a custom class.
+If it is possible to use `o-labels` classes we recommend [oLabels](#sass) and [oLabelsAddStates](#custom-standard-label-state) instead. Using these will help reduce the size of your CSS bundle where multiple labels are used.
 
-_For an indicator label see `oLabelsIndicatorContent`, and for a timestamp label see `oLabelsTimestampContent`._
-
-If it is possible to use `o-labels` classes we recommend [oLabels](#mixin-olabels) and [oLabelsAddStates](#mixin-olabelsaddstate) instead. Using these will help reduce the size of your CSS bundle where mutliple labels are used.
+### oLabelsContent
 
 `oLabelsContent` accepts an `$opts` argument which is a map of options. To output styles required by all labels set "base" to "true". Then set the labels "[sizes](#size)" and its "[state](#states)". Any of these options may be output independently.
 
@@ -228,34 +269,28 @@ To output a custom label:
 }
 ```
 
-### Sizes
+### oLabelsIndicatorContent
 
-This table outlines all of the possible sizes you can request in the [`oLabels` mixin](#mixin-olabels):
+As styles for the indicator label apply to multiple html elements, the `oLabelsIndicatorContent` accepts an `$opts` argument to output styles for each element separately.
 
-| Size  | Description                                 | Brand support                |
-|-------|---------------------------------------------|------------------------------|
-| big   | Label with increased font size and padding. | master, internal, whitelabel |
-| small | Label with decreased font size and padding. | master, internal, whitelabel |
-
-### States
-
-This table outlines all of the possible states you can request in the [`oLabels` mixin](#mixin-olabels) and [`oLabelsAddState` mixin](#mixin-olabelsaddstate):
-
-| Size                 | Description                                                   | Brand support |
-|----------------------|---------------------------------------------------------------|---------------|
-| content-commercial   | Used to identify paid posts or promoted content.              | master        |
-| content-premium      | Used to identify premium content.                             | master        |
-| lifecycle-beta       | Used to identify a feature that's in beta.                    | master        |
-| support-active       | Used to indicate that a component is actively maintained.     | internal      |
-| support-maintained   | Used to indicate that a component is maintained.              | internal      |
-| support-experimental | Used to indicate that a component is an experimental feature. | internal      |
-| support-deprecated   | Used to indicate that a component is deprecated.              | internal      |
-| support-dead         | Used to indicate that a component is no longer worked on.     | internal      |
-| tier-platinum        | Used to indicate a service with a platinum service tier.      | internal      |
-| tier-gold            | Used to indicate a service with a gold service tier.          | internal      |
-| tier-silver          | Used to indicate a service with a silver service tier.        | internal      |
-| tier-bronze          | Used to indicate a service with a bronze service tier.        | internal      |
-
+```scss
+// equivalent to .o-labels-indicator
+.my-indicator-label {
+	@include oLabelsIndicatorContent($opts: ('block': true));
+}
+// equivalent to .o-labels-indicator--live
+.my-indicator-label--live {
+	@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'live'));
+}
+// equivalent to .o-labels-indicator__status
+.my-indicator-label__status {
+	@include oLabelsIndicatorContent($opts: ('element': 'status'));
+}
+// equivalent to .o-labels-indicator__timestamp
+.my-indicator-label__timestamp {
+	@include oLabelsIndicatorContent($opts: ('element': 'timestamp'));
+}
+```
 
 ## Migration guide
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This table outlines the possible indicator label statuses:
 | Size                 | Description                                                   | Brand support |
 |----------------------|---------------------------------------------------------------|---------------|
 | live                 | Indicate a story is live.                                     | master        |
+| live                 | Indicate a live story is no longer live.                                     | master        |
 | new                  | Indicate a story is new.                                      | master        |
 | updated              | Indicate a story has been updated.                            | master        |
 
@@ -123,6 +124,7 @@ The following internal brand states are used to represent the FT's service tiers
 
 Indicator labels have one of three statuses:
 - `live`
+- `closed`
 - `updated`
 - `new`
 
@@ -135,7 +137,7 @@ Use the following markup for a live label:
 </span>
 ```
 
-For an updated or new label, use the associated modifier class, e.g. `o-labels-indicator--updated`, and add a child element `o-labels-indicator__timestamp` to show the new/updated time. We recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
+For a closed, updated, or new label, use the associated modifier class, e.g. `o-labels-indicator--updated`, and add a child element `o-labels-indicator__timestamp` to show the new/updated time. We recommend using [o-date](https://registry.origami.ft.com/components/o-date) to format the timestamp element.
 
 ```html
 <span class="o-labels-indicator o-labels-indicator--new">

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Labels for content classification, to emphasise a value, or highlight a status.
 ## Label Types
 
 There are three types of label:
-- A standard label, the default.
-- An indicator label.
-- A timestamp label.
+- [A standard label](#standard-label), the default.
+- [An indicator label](#indicator-label).
+- [A timestamp label](#timestamp-label).
 
 ### Standard Label
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "o-colors": "^5.0.0",
     "o-typography": "^6.0.0",
     "o-brand": "^3.2.5",
-    "o-spacing": "^2.0.0"
+    "o-spacing": "^2.0.0",
+    "o-editorial-typography": "^1.0.10"
   }
 }

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,0 +1,13 @@
+{{#standard}}
+<span class="my-label">
+    custom markup
+</span>
+{{/standard}}
+
+{{#indicator}}
+<span class="my-indicator-label my-indicator-label--live">
+    <span class="my-indicator-label__status">
+        custom markup
+    </span>
+</span>
+{{/indicator}}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -4,13 +4,43 @@ $o-labels-is-silent: false;
 @import "../../main";
 
 body {
-	background: oColorsByUsecase('page', 'background');
-
 	// Important used to ensure that this overrides the `body` specificity
 	// provided by the build service
 	margin: 1em !important; // stylelint-disable-line declaration-no-important
 }
 
+html {
+	background: oColorsByUsecase('page', 'background');
+}
+
+.demo-inverse {
+	background: oColorsByName('slate');
+}
+
 .demo-container {
 	margin-bottom: 1em;
+}
+
+// custom standard label markup
+.my-label {
+	@include oLabelsContent($opts: (
+		'base': true
+	));
+}
+
+// custom indicator label markup
+.my-indicator-label {
+	@include oLabelsIndicatorContent($opts: ('block': true));
+}
+
+.my-indicator-label--live {
+	@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'live'));
+}
+
+.my-indicator-label__status {
+	@include oLabelsIndicatorContent($opts: ('element': 'status'));
+}
+
+.my-indicator-label__date {
+	@include oLabelsIndicatorContent($opts: ('element': 'timestamp'));
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -4,9 +4,7 @@ $o-labels-is-silent: false;
 @import "../../main";
 
 body {
-	// Important used to ensure that this overrides the `body` specificity
-	// provided by the build service
-	margin: 1em !important; // stylelint-disable-line declaration-no-important
+	padding: 1rem;
 }
 
 html {
@@ -15,10 +13,6 @@ html {
 
 .demo-inverse {
 	background: oColorsByName('slate');
-}
-
-.demo-container {
-	margin-bottom: 1em;
 }
 
 // custom standard label markup

--- a/demos/src/indicators.mustache
+++ b/demos/src/indicators.mustache
@@ -1,0 +1,29 @@
+<span class="o-labels-indicator o-labels-indicator--live{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        live
+    </span>
+</span>
+
+<br>
+
+<span class="o-labels-indicator o-labels-indicator--new{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        new
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<br>
+
+<span class="o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        updated
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>

--- a/demos/src/indicators.mustache
+++ b/demos/src/indicators.mustache
@@ -6,6 +6,14 @@
 
 <br>
 
+<span class="o-labels-indicator o-labels-indicator--closed{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        closed
+    </span>
+</span>
+
+<br>
+
 <span class="o-labels-indicator o-labels-indicator--new{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
     <span class="o-labels-indicator__status">
         new

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,8 +1,6 @@
 
 {{#states}}
-	<div class="demo-container">
 		<span class="o-labels o-labels--{{.}}">Testing</span>
 		<span class="o-labels o-labels--{{.}} o-labels--big">Testing</span>
 		<span class="o-labels o-labels--{{.}} o-labels--small">Testing</span>
-	</div>
 {{/states}}

--- a/demos/src/timestamp.mustache
+++ b/demos/src/timestamp.mustache
@@ -1,0 +1,4 @@
+<time class="o-labels-timestamp{{#modifiers}} o-labels-timestamp--{{.}}{{/modifiers}}">
+    <!-- demo datetime: see o-date for formatting -->
+    <time datetime="2016-02-29T12:35:48Z" title="February 29 2016 12:35 pm" aria-label="February 29 2016">February 29 2016</time>
+</time>

--- a/main.scss
+++ b/main.scss
@@ -76,20 +76,20 @@
 	}
 
 	// Timestamp label styles
-	@if $indicator-label-status {
+	@if $indicator-label-status and _oLabelsSupports('timestamps') {
 		.o-labels-timestamp {
 			@include oLabelsTimestampContent();
 		}
-	}
 
-	@if $indicator-label-status and $timestamp-label-inverse {
-		.o-labels-timestamp--inverse {
-			@extend %_o-labels-timestamp--inverse;
+		@if $timestamp-label-inverse {
+			.o-labels-timestamp--inverse {
+				@extend %_o-labels-timestamp--inverse;
+			}
 		}
 	}
 
 	// Indicator label styles
-	@if $indicator-label-status {
+	@if $indicator-label-status and _oLabelsSupports('indicators') {
 		.o-labels-indicator {
 			@include oLabelsIndicatorContent($opts: ('block': true));
 		}
@@ -97,17 +97,17 @@
 		.o-labels-indicator__status {
 			@include oLabelsIndicatorContent($opts: ('element': 'status'));
 		}
-	}
 
-	@each $indicator-state in $indicator-label-status {
-		.o-labels-indicator--#{$indicator-state} {
-			@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': $indicator-state));
+		@each $indicator-status in $indicator-label-status {
+			.o-labels-indicator--#{$indicator-status} {
+				@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': $indicator-status));
+			}
 		}
-	}
 
-	@if $indicator-label-status and $indicator-label-inverse {
-		.o-labels-indicator--inverse {
-			@extend %_o-labels-timestamp--inverse;
+		@if $indicator-label-inverse {
+			.o-labels-indicator--inverse {
+				@extend %_o-labels-timestamp--inverse;
+			}
 		}
 	}
 }

--- a/main.scss
+++ b/main.scss
@@ -2,10 +2,12 @@
 @import 'o-brand/main';
 @import "o-colors/main";
 @import "o-typography/main";
+@import "o-editorial-typography/main";
 
 @import "src/scss/colors";
 @import "src/scss/brand";
 @import "src/scss/variables";
+@import "src/scss/placeholders";
 @import "src/scss/mixins";
 
 /// Outputs all available features and styles for labels.
@@ -14,32 +16,98 @@
 /// @output The output includes the `.o-labels` class definition as well as class definitions for every variant.
 /// @example scss - All label styles
 ///   @include oLabels();
-/// @example scss - Base styles, big size variant, and gold tier state variant
+/// @example scss - Standard label styles including big size and gold tier state variants
 ///   @include oLabels($opts: ('sizes': ('big'), 'states': ('tier-gold'));
+/// @example scss - Indicator label styles including live and new variants
+///   @include oLabels($opts: ('indicators': ('status': ('live', 'new')));
+/// @example scss - Indicator label styles with inverse modifier class
+///   @include oLabels($opts: ('indicators': ('status': ('live', 'new'), 'inverse': true));
+/// @example scss - Timestamp label with inverse modifier class
+///   @include oLabels($opts: ('timestamp': ('inverse': true));
 /// @access public
 @mixin oLabels($opts: (
-	'sizes': $_o-labels-sizes,
-	'states': $_o-labels-states
+	'sizes': $_o-labels-standard-sizes,
+	'states': $_o-labels-standard-states,
+	'indicators': (
+		'status': $_o-labels-indicator-status,
+		'inverse': true,
+	),
+	'timestamp': (
+		'inverse': true
+	)
 )) {
-	$sizes: map-get($opts, 'sizes');
-	$states: map-get($opts, 'states');
+	// Get standard labels to include
+	$standard-label-sizes: map-get($opts, 'sizes');
+	$standard-label-states: map-get($opts, 'states');
+	// Get indicator labels to include
+	$indicator-label-opts: map-get($opts, 'indicators');
+	$indicator-label-opts: if(
+		type-of($indicator-label-opts) == 'map',
+		$indicator-label-opts,
+		()
+	);
+	$indicator-label-status: map-get($indicator-label-opts, 'status');
+	$indicator-label-inverse: map-get($indicator-label-opts, 'inverse');
+	// Get whether to include the timestamp label
+	$timestamp-label: map-get($opts, 'timestamp');
+	$timestamp-label-inverse: if(
+		type-of($timestamp-label) == 'map',
+		map-get($timestamp-label, 'inverse'),
+		$timestamp-label
+	);
 
-	// Base label styles
+	// Base standard label styles
 	.o-labels {
 		@include _oLabelsBaseContent();
 	}
 
-	// Label size variants
-	@each $size in $_o-labels-sizes {
-		@if index($sizes, $size) and _oLabelsSupports($size) {
+	// Standard label size variants
+	@each $size in $_o-labels-standard-sizes {
+		@if index($standard-label-sizes, $size) and _oLabelsSupports($size) {
 			@include _oLabelsSize($size);
 		}
 	}
 
-	// Label state variants
-	@each $state in $_o-labels-states {
-		@if index($states, $state) and _oLabelsSupports($state) {
+	// Standard label state variants
+	@each $state in $_o-labels-standard-states {
+		@if index($standard-label-states, $state) and _oLabelsSupports($state) {
 			@include oLabelsAddState($state);
+		}
+	}
+
+	// Timestamp label styles
+	@if $indicator-label-status {
+		.o-labels-timestamp {
+			@include oLabelsTimestampContent();
+		}
+	}
+
+	@if $indicator-label-status and $timestamp-label-inverse {
+		.o-labels-timestamp--inverse {
+			@extend %_o-labels-timestamp--inverse;
+		}
+	}
+
+	// Indicator label styles
+	@if $indicator-label-status {
+		.o-labels-indicator {
+			@include oLabelsIndicatorContent($opts: ('block': true));
+		}
+
+		.o-labels-indicator__status {
+			@include oLabelsIndicatorContent($opts: ('element': 'status'));
+		}
+	}
+
+	@each $indicator-state in $indicator-label-status {
+		.o-labels-indicator--#{$indicator-state} {
+			@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': $indicator-state));
+		}
+	}
+
+	@if $indicator-label-status and $indicator-label-inverse {
+		.o-labels-indicator--inverse {
+			@extend %_o-labels-timestamp--inverse;
 		}
 	}
 }

--- a/origami.json
+++ b/origami.json
@@ -89,6 +89,9 @@
 			"name": "indicators",
 			"title": "Indicators",
 			"description": "",
+			"brands": [
+				"master"
+			],
 			"template": "/demos/src/indicators.mustache"
 		},
 		{
@@ -97,12 +100,18 @@
 			"description": "",
 			"data": {"modifiers": ["inverse"]},
 			"documentClasses": "demo-inverse",
+			"brands": [
+				"master"
+			],
 			"template": "/demos/src/indicators.mustache"
 		},
 		{
 			"name": "timestamp",
 			"title": "Timestamp",
 			"description": "",
+			"brands": [
+				"master"
+			],
 			"template": "/demos/src/timestamp.mustache"
 		},
 		{
@@ -111,6 +120,9 @@
 			"description": "",
 			"data": {"modifiers": ["inverse"]},
 			"documentClasses": "demo-inverse",
+			"brands": [
+				"master"
+			],
 			"template": "/demos/src/timestamp.mustache"
 		},
 		{
@@ -125,7 +137,9 @@
 			"name": "custom-indicator",
 			"template": "demos/src/custom.mustache",
 			"data": {"indicator": true},
-			"brands": ["master"],
+			"brands": [
+				"master"
+			],
 			"hidden": true
 		},
 		{

--- a/origami.json
+++ b/origami.json
@@ -86,6 +86,49 @@
 			"template": "/demos/src/typography.mustache"
 		},
 		{
+			"name": "indicators",
+			"title": "Indicators",
+			"description": "",
+			"template": "/demos/src/indicators.mustache"
+		},
+		{
+			"name": "indicators-inverse",
+			"title": "Inverse Indicators",
+			"description": "",
+			"data": {"modifiers": ["inverse"]},
+			"documentClasses": "demo-inverse",
+			"template": "/demos/src/indicators.mustache"
+		},
+		{
+			"name": "timestamp",
+			"title": "Timestamp",
+			"description": "",
+			"template": "/demos/src/timestamp.mustache"
+		},
+		{
+			"name": "timestamp-inverse",
+			"title": "Inverse Timestamp",
+			"description": "",
+			"data": {"modifiers": ["inverse"]},
+			"documentClasses": "demo-inverse",
+			"template": "/demos/src/timestamp.mustache"
+		},
+		{
+			"title": "Standard Label With Custom Markup",
+			"name": "custom",
+			"template": "demos/src/custom.mustache",
+			"data": {"standard": true},
+			"hidden": true
+		},
+		{
+			"title": "Indicator Label With Custom Markup",
+			"name": "custom-indicator",
+			"template": "demos/src/custom.mustache",
+			"data": {"indicator": true},
+			"brands": ["master"],
+			"hidden": true
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "demos/src/pa11y.mustache",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -51,6 +51,8 @@ $_o-labels-shared-brand-config: (
 			)
 		)),
 		'supports-variants': (
+			'indicators',
+			'timestamps',
 			'big',
 			'small',
 			'content-commercial',

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -128,6 +128,9 @@
 ///    .my-indicator-label--updated {
 ///        @include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'updated'));
 ///    }
+///    .my-indicator-label--closed {
+///        @include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'closed'));
+///    }
 ///    .my-indicator-label--live {
 ///        @include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'live'));
 ///    }
@@ -197,18 +200,22 @@
 }
 
 /// Styles for indicator label statuses.
-/// @param {Sting} $status - An existing indicator status e.g. live, new, updated
+/// @param {Sting} $status - An existing indicator status e.g. live, closed, new, updated
 /// @access private
 @mixin _oLabelsIndicatorStatusContent($status) {
 	@if not index($_o-labels-indicator-status, $status) {
 		@error '"#{$status}" is not an indicator label status. ' +
 			'Expected one or more of the following statuses: #{$_o-labels-indicator-status}.';
 	}
-	// all indicator labels are currently timestamps with the same colour,
-	// it is not possible to customise indicator labels currently but this
+	// All indicator labels currently use the same colour except the "closed".
+	// It is not possible to customise indicator labels currently but this
 	// may be added in the future, e.g. for the internal brand:
 	// https://github.com/Financial-Times/o-labels/issues/58
-	@extend %_o-labels-indicator-live-color;
+	@if $status == 'closed' {
+		@extend %_o-labels-indicator-closed-color;
+	} @else {
+		@extend %_o-labels-indicator-live-color;
+	}
 	@extend %_o-labels-timestamp-typography;
 
 	@if($status == 'live') {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -222,6 +222,15 @@
 			transform: scale(1.5);
 			animation: _o-labels-live-pulse 1.7s ease infinite;
 			order: -1;
+			// Prevent animation of the live label if the reader has indicated
+			// that they prefer reduced motion. This may be conservative but
+			// as the live indicator is presented alongside content (including
+			// the front page at the time of writing) we do not want to risk
+			// severely distracting some readers.
+			// https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html
+			@media (prefers-reduced-motion) {
+				animation: none;
+			}
 		}
 
 		// output keyframes once when live status is output

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -35,14 +35,15 @@
 	}
 }
 
-/// Add a state modifier for labels.
+/// Add a state modifier for standard labels.
+/// Note this mixin is dor standard labels only, not indicator labels.
 ///
-/// @param {String|Map} $state-name - The label state to output styles for. See README for available states.
-/// @param {Map} $opts [null] - A brand configuration which can be used to create custom label states. See README for more examples.
+/// @param {String|Map} $state-name - The standard label state to output styles for. See README for available states.
+/// @param {Map} $opts [null] - A brand configuration which can be used to create custom standard label states. See README for more examples.
 /// @output The output includes the `.o-labels--STATE` modifier class definition, which includes all overrides.
-/// @example scss - Existing label state
+/// @example scss - Existing standard label state
 ///   @include oLabelsAddState('tier-gold');
-/// @example scss - Custom label state
+/// @example scss - Custom standard label state
 ///   @include oLabelsAddState('citrus-fruit', (
 ///       background-color: oColorsByName('lemon')
 ///   ));
@@ -54,11 +55,11 @@
 	$variant: if($opts, $opts, $state-name);
 
 	.o-labels--#{$state-name} {
-		@include _oLabelsStateContent($variant);
+		@include _oLabelsStandardStateContent($variant);
 	}
 }
 
-/// Styles for a label without an `o-loading` CSS class.
+/// Styles for a standard label without an `o-labels` CSS class.
 /// Recommended only when a custom class name is required, for example within another component.
 /// @output Styles for a label without a CSS selector.
 /// @param {Map} $opts - A map containing a boolean to output base label styles, plus the label size and state (a state name or custom state map).
@@ -87,7 +88,7 @@
 	}
 
 	@if $state {
-		@include _oLabelsStateContent($state);
+		@include _oLabelsStandardStateContent($state);
 	}
 
 	@if $size {
@@ -95,7 +96,75 @@
 	}
 }
 
-/// Styles to change the size of the label.
+
+/// Styles for a timestamp label i.e. .o-labels-timestamp.
+/// This mixin is not recommend. Instead the the `oLabels` primary mixin and
+/// o-labels markup. This should only be used where using o-labels markup is
+/// not possible.
+///
+/// If outputting a timestamp in a non-label context see
+/// [o-editorial-typography](https://registry.origami.ft.com/components/o-editorial-typography).
+///
+/// @example Output a timestamp label with custom markup.
+///    .my-timestamp-label {
+///        @include oLabelsTimestampContent();
+///    }
+/// @access public
+@mixin oLabelsTimestampContent() {
+	@extend %_o-labels-timestamp;
+}
+
+/// Styles for indicator label elements e.g. .o-labels-indicator.
+/// This mixin is not recommend. Instead the the `oLabels` primary mixin and
+/// o-labels markup. This should only be used where using o-labels markup is
+/// not possible.
+/// @example Output indicator labels with custom markup.
+///    .my-indicator-label {
+///        @include oLabelsIndicatorContent($opts: ('block': true));
+///    }
+///    .my-indicator-label--new {
+///        @include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'new'));
+///    }
+///    .my-indicator-label--updated {
+///        @include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'updated'));
+///    }
+///    .my-indicator-label--live {
+///        @include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'live'));
+///    }
+///    .my-indicator-label__status {
+///        @include oLabelsIndicatorContent($opts: ('element': 'status'));
+///    }
+///    .my-indicator-label__timestamp {
+///        @include oLabelsIndicatorContent($opts: ('element': 'timestamp'));
+///    }
+/// @param {Sting|Map} $ops - the BEM element to output styles for, see example.
+/// @access public
+@mixin oLabelsIndicatorContent($opts: ()) {
+	$modifier: map-get($opts, 'modifier');
+	$element: map-get($opts, 'element');
+	$block: map-get($opts, 'block');
+	// Validate element.
+	// The timestamp element .o-labels-indicator__timestamp element
+	// currently has no styles but may do in the future.
+	$valid-elements: ('status', 'timestamp');
+	@if $element and not index($valid-elements, $element) {
+		@error 'Element must be one of "#{$valid-elements}" if set. "#{$element}" given.';
+	}
+	// Output block "base" styles i.e .o-labels-indicator
+	@if $block and not $modifier {
+		@extend %_o-labels-indicator;
+	}
+	// Output modifier styles e.g .o-labels-indicator--live
+	@if $block and $modifier {
+		@include _oLabelsIndicatorStatusContent($modifier);
+	}
+	// Output status element styles i.e .o-labels-indicator__status
+	@if $element == 'status' {
+		@extend %_o-labels-indicator__status;
+	}
+}
+
+/// Styles to change the size of a standard label.
 /// @param {Sting} $size - The label size to output styles for. The valid sizes are `big` and `small`.
 /// @access private
 @mixin _oLabelsSizeContent($size) {
@@ -109,7 +178,7 @@
 /// Styles for a state.
 /// @param {Sting|Map} $variant - An existing state name or a custom state map.
 /// @access private
-@mixin _oLabelsStateContent($variant) {
+@mixin _oLabelsStandardStateContent($variant) {
 	background-color: _oLabelsGet('background-color', $variant);
 	border-color: _oLabelsGet('border-color', $variant);
 	text-transform: _oLabelsGet('text-transform', $variant);
@@ -124,5 +193,51 @@
 	// Set the spacing
 	@if _oLabelsGet('padding-vertical', $variant) and _oLabelsGet('padding-horizontal', $variant) {
 		padding: (_oLabelsGet('padding-vertical', $variant) - _oLabelsGet('border-width')) (_oLabelsGet('padding-horizontal', $variant) - _oLabelsGet('border-width'));
+	}
+}
+
+/// Styles for indicator label statuses.
+/// @param {Sting} $status - An existing indicator status e.g. live, new, updated
+/// @access private
+@mixin _oLabelsIndicatorStatusContent($status) {
+	@if not index($_o-labels-indicator-status, $status) {
+		@error '"#{$status}" is not an indicator label status. ' +
+			'Expected one or more of the following statuses: #{$_o-labels-indicator-status}.';
+	}
+	// all indicator labels are currently timestamps with the same colour,
+	// it is not possible to customise indicator labels currently but this
+	// may be added in the future, e.g. for the internal brand:
+	// https://github.com/Financial-Times/o-labels/issues/58
+	@extend %_o-labels-indicator-live-color;
+	@extend %_o-labels-timestamp-typography;
+
+	@if($status == 'live') {
+		& > %_o-labels-indicator__status:after {
+			@extend %_o-labels-indicator-circle;
+		}
+
+		& > %_o-labels-indicator__status:after {
+			margin-right: -$_o-labels-indicator-circle-size;
+			opacity: 0.2;
+			transform: scale(1.5);
+			animation: _o-labels-live-pulse 1.7s ease infinite;
+			order: -1;
+		}
+
+		// output keyframes once when live status is output
+		@if($status == 'live' and $_o-labels-indicator-live-pulse-output: false) {
+			$_o-labels-indicator-live-pulse-output: true !global;
+			@keyframes _o-labels-live-pulse {
+				0% {
+					transform: scale(1.5);
+				}
+				50% {
+					transform: scale(1);
+				}
+				100% {
+					transform: scale(1.5);
+				}
+			}
+		}
 	}
 }

--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -1,0 +1,61 @@
+
+// Do not output placeholders twice i.e. if o-labels is imported twice.
+// This is a temporary variable, until we can use the new sass `@use` feature
+// that will not have the problem of re-outputting placeholders on every import
+$_o-labels-first-import: true !default;
+
+@if $_o-labels-first-import == true {
+	// shared placeholders
+	%_o-labels-indicator-size {
+		@include oTypographySans(-2);
+	}
+
+	%_o-labels-timestamp-typography {
+		@include oEditorialTypographyTimestamp();
+	}
+
+	// must come after %_o-labels-timestamp-typography
+	// for higher specificity
+	%_o-labels-indicator-live-color {
+		color: oColorsByName('crimson');
+	}
+
+	%_o-labels-indicator-circle {
+		content: '';
+		position: relative;
+		left: 0;
+		width: $_o-labels-indicator-circle-size;
+		height: $_o-labels-indicator-circle-size;
+		margin-right: 5px;
+		border-radius: 50%;
+		background-color: currentcolor;
+		display: inline-block;
+	}
+
+	// timestamp block placeholders
+	%_o-labels-timestamp {
+		@extend %_o-labels-timestamp-typography;
+		@extend %_o-labels-indicator-size;
+	}
+
+	%_o-labels-timestamp--inverse {
+		color: oColorsByName('white');
+	}
+
+	// indicator block placeholders
+	%_o-labels-indicator {
+		@extend %_o-labels-indicator-size;
+		position: relative;
+		display: inline-block;
+	}
+
+	%_o-labels-indicator__status {
+		display: inline-flex;
+		align-items: center;
+		&:before {
+			@extend %_o-labels-indicator-circle;
+		}
+	}
+}
+
+$_o-labels-first-import: false;

--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -20,6 +20,12 @@ $_o-labels-first-import: true !default;
 		color: oColorsByName('crimson');
 	}
 
+	// must come after %_o-labels-timestamp-typography
+	// for higher specificity
+	%_o-labels-indicator-closed-color {
+		color: oColorsByName('black-60');
+	}
+
 	%_o-labels-indicator-circle {
 		content: '';
 		position: relative;
@@ -38,6 +44,9 @@ $_o-labels-first-import: true !default;
 		@extend %_o-labels-indicator-size;
 	}
 
+	// must come after other colour placeholders
+	// e.g. %_o-labels-indicator-live-color
+	// for higher specificity
 	%_o-labels-timestamp--inverse {
 		color: oColorsByName('white');
 	}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -49,6 +49,7 @@ $_o-labels-standard-states: (
 /// @access private
 $_o-labels-indicator-status: (
 	'live',
+	'closed',
 	'new',
 	'updated'
 );

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -53,5 +53,13 @@ $_o-labels-indicator-status: (
 	'updated'
 );
 
+/// The width/height of the circle used in the indicator label.
+/// @type Number
+/// @access private
 $_o-labels-indicator-circle-size: #{(10/12)}em; // 10px given 12px font size
+
+/// Whether or not the animation keyframes for the live indicator
+/// label has already been output.
+/// @type Boolean
+/// @access private
 $_o-labels-indicator-live-pulse-output: false !default;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -6,24 +6,28 @@
 /// @access public
 $o-labels-is-silent: true !default;
 
-/// Label sizes
-/// A list used to loop over all label sizes.
+/// Standard label sizes
+/// A list used to loop over all standard label sizes.
+/// These do not apply to other label types such as
+// indicator labels.
 /// For actual values: (@see _brand.scss).
 ///
 /// @type List
 /// @access private
-$_o-labels-sizes: (
+$_o-labels-standard-sizes: (
 	'big',
 	'small'
 );
 
-/// Label states
-/// A list used to loop over all label states.
+/// Standard label states
+/// A list used to loop over all standard label states.
+/// These do not apply to other label types such as
+// indicator labels.
 /// For actual values: (@see _brand.scss).
 ///
 /// @type List
 /// @access private
-$_o-labels-states: (
+$_o-labels-standard-states: (
 	'content-commercial',
 	'content-premium',
 	'lifecycle-beta',
@@ -37,3 +41,17 @@ $_o-labels-states: (
 	'tier-platinum',
 	'tier-silver'
 );
+
+/// Indicator label states
+/// A list used to loop over all indicator label states.
+///
+/// @type List
+/// @access private
+$_o-labels-indicator-status: (
+	'live',
+	'new',
+	'updated'
+);
+
+$_o-labels-indicator-circle-size: #{(10/12)}em; // 10px given 12px font size
+$_o-labels-indicator-live-pulse-output: false !default;


### PR DESCRIPTION
Addresses: https://github.com/Financial-Times/o-labels/issues/80
Beta release in the registry: https://registry.origami.ft.com/components/o-labels@5.1.0-beta.1.0.0/

Adds indicator and timestamp labels to `o-labels` with an inverse variant. These styles 
match  styles found in [o-teaser](https://github.com/Financial-Times/o-teaser/blob/master/src/scss/elements/_timestamp.scss) and [live blogs](https://github.com/Financial-Times/next-article/blob/cf51a94382cb9fb1b98dfb144781e456565736ca/client/components/live-event/_status.scss#L1), which will be updated to remove 
duplication by using `o-labels`.

If a `font-size`, `line-height`, or `color` property is set on the root element these new 
indicator styles will adapt accordingly. This will allow us to add new variants in the future 
with minimal extra styles or enable products to overrides these properties for one-off uses 
more easily.

<img width="1428" alt="Screenshot 2020-07-13 at 14 25 48" src="https://user-images.githubusercontent.com/10405691/87309657-cc8c8380-c514-11ea-9e1f-670b9f343786.png">
<img width="1428" alt="Screenshot 2020-07-13 at 14 25 52" src="https://user-images.githubusercontent.com/10405691/87309662-cdbdb080-c514-11ea-90ea-e041ce492113.png">
<img width="1428" alt="Screenshot 2020-07-13 at 14 25 54" src="https://user-images.githubusercontent.com/10405691/87309667-ceeedd80-c514-11ea-8469-a3a61bc97d27.png">
<img width="1428" alt="Screenshot 2020-07-13 at 14 25 56" src="https://user-images.githubusercontent.com/10405691/87309673-d0200a80-c514-11ea-9d67-df942b17f2a8.png">

New "content" mixins will allow us to use indicator and timestamp labels in other
components (i.e. [o-teaser](https://github.com/Financial-Times/o-teaser/blob/master/src/scss/elements/_timestamp.scss)).
As the indicator labels use multiple html elements the mixin needs to be able to output
styles for each element separately. This is a little complicated. Difficult to document and
maintain. It links back to the [component composition issue](https://github.com/Financial-Times/origami/issues/45).