### PR TITLE
Update indicator style (animation and size)

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -17,6 +17,19 @@ html {
 	}
 }
 
+.demo-scale-m1 {
+	@include oTypographySans($scale: -1);
+}
+.demo-scale-0 {
+	@include oTypographySans($scale: 0);
+}
+.demo-scale-1 {
+	@include oTypographySans($scale: 1);
+}
+.demo-scale-2 {
+	@include oTypographySans($scale: 3);
+}
+
 // custom standard label markup
 .my-label {
 	@include oLabelsContent($opts: (
@@ -40,3 +53,5 @@ html {
 .my-indicator-label__date {
 	@include oLabelsIndicatorContent($opts: ('element': 'timestamp'));
 }
+
+

--- a/demos/src/indicators-sizes.mustache
+++ b/demos/src/indicators-sizes.mustache
@@ -1,0 +1,157 @@
+<span class="demo-scale-m1 o-labels-indicator o-labels-indicator--live{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        live
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-m1 o-labels-indicator o-labels-indicator--closed{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        closed
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-m1 o-labels-indicator o-labels-indicator--new{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        new
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<br>
+
+<span class="demo-scale-m1 o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        updated
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<hr>
+
+<span class="demo-scale-0 o-labels-indicator o-labels-indicator--live{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        live
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-0 o-labels-indicator o-labels-indicator--closed{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        closed
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-0 o-labels-indicator o-labels-indicator--new{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        new
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<br>
+
+<span class="demo-scale-0 o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        updated
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<hr>
+
+<span class="demo-scale-1 o-labels-indicator o-labels-indicator--live{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        live
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-1 o-labels-indicator o-labels-indicator--closed{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        closed
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-1 o-labels-indicator o-labels-indicator--new{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        new
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<br>
+
+<span class="demo-scale-2 o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        updated
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<hr>
+
+<span class="demo-scale-2 o-labels-indicator o-labels-indicator--live{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        live
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-2 o-labels-indicator o-labels-indicator--closed{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        closed
+    </span>
+</span>
+
+<br>
+
+<span class="demo-scale-2 o-labels-indicator o-labels-indicator--new{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        new
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>
+
+<br>
+
+<span class="demo-scale-2 o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+    <span class="o-labels-indicator__status">
+        updated
+    </span>
+    <time class="o-labels-indicator__timestamp">
+        <!-- demo time element only (the datetime is not 1 hour ago): use o-date for dynamic datetime formatting -->
+        <time datetime="2020-07-09T12:52:33+0000" title="July 9 2020 1:52 pm" aria-label="1 hours ago">1 hour ago</time>
+    </time>
+</span>

--- a/demos/src/indicators-sizes.mustache
+++ b/demos/src/indicators-sizes.mustache
@@ -106,7 +106,7 @@
 
 <br>
 
-<span class="demo-scale-2 o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
+<span class="demo-scale-1 o-labels-indicator o-labels-indicator--updated{{#modifiers}} o-labels-indicator--{{.}}{{/modifiers}}">
     <span class="o-labels-indicator__status">
         updated
     </span>

--- a/origami.json
+++ b/origami.json
@@ -103,6 +103,15 @@
 			"template": "/demos/src/indicators.mustache"
 		},
 		{
+			"name": "indicators-sizes",
+			"title": "Indicator Sizes",
+			"description": "All indicator labels adapt to the set font size. This demo shows using custom CSS to set the font size of indicator labels.",
+			"brands": [
+				"master"
+			],
+			"template": "/demos/src/indicators-sizes.mustache"
+		},
+		{
 			"name": "timestamp",
 			"title": "Timestamp",
 			"description": "",

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -219,16 +219,8 @@
 	@extend %_o-labels-timestamp-typography;
 
 	@if($status == 'live') {
-		& > %_o-labels-indicator__status:after {
-			@extend %_o-labels-indicator-circle;
-		}
-
-		& > %_o-labels-indicator__status:after {
-			margin-right: calc((#{$_o-labels-indicator-circle-size-calc}) * -1);
-			opacity: 0.2;
-			transform: scale(1.5);
-			animation: _o-labels-live-pulse 1.7s ease infinite;
-			order: -1;
+		& > %_o-labels-indicator__status:before {
+			animation: _o-labels-live-pulse 1.2s ease-in-out infinite;
 			// Prevent animation of the live label if the reader has indicated
 			// that they prefer reduced motion. This may be conservative but
 			// as the live indicator is presented alongside content (including
@@ -245,13 +237,16 @@
 			$_o-labels-indicator-live-pulse-output: true !global;
 			@keyframes _o-labels-live-pulse {
 				0% {
-					transform: scale(1.5);
+					opacity: 1;
 				}
-				50% {
-					transform: scale(1);
+				30% {
+					opacity: 0.4;
+				}
+				70% {
+					opacity: 0.4;
 				}
 				100% {
-					transform: scale(1.5);
+					opacity: 1;
 				}
 			}
 		}

--- a/src/scss/_placeholders.scss
+++ b/src/scss/_placeholders.scss
@@ -26,25 +26,6 @@ $_o-labels-first-import: true !default;
 		color: oColorsByName('black-60');
 	}
 
-	%_o-labels-indicator-circle {
-		content: '';
-		position: relative;
-		left: 0;
-		width: calc(#{$_o-labels-indicator-circle-size-calc});
-		height: calc(#{$_o-labels-indicator-circle-size-calc});
-		// At some font sizes the width/height of the circle is a decimal.
-		// For small font sizes, i.e 14px, the browser renders the circle
-		// squashed, even though the width/height are equal. Setting the
-		// transform property changes the way the browser renders the circle,
-		// in a way which overcomes this problem
-		transform: scale(1);
-		margin-right: 5px;
-		border-radius: 50%;
-		background-color: currentcolor;
-		display: inline-block;
-		align-self: center;
-	}
-
 	// timestamp block placeholders
 	%_o-labels-timestamp {
 		@extend %_o-labels-timestamp-typography;
@@ -61,15 +42,23 @@ $_o-labels-first-import: true !default;
 	// indicator block placeholders
 	%_o-labels-indicator {
 		@extend %_o-labels-indicator-size;
-		position: relative;
 		display: inline-block;
 	}
 
 	%_o-labels-indicator__status {
-		display: inline-flex;
-		align-items: baseline;
 		&:before {
-			@extend %_o-labels-indicator-circle;
+			content: '';
+			width: calc(0.5em + 4px);
+			height: calc(0.5em + 4px);
+			min-width: 10px;
+			min-height: 10px;
+			margin-right: 2px;
+			border-radius: 50%;
+			background-color: currentcolor;
+			display: inline-block;
+			vertical-align: baseline;
+			// align better with MetricWeb
+			margin-bottom: -1px;
 		}
 	}
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -54,11 +54,6 @@ $_o-labels-indicator-status: (
 	'updated'
 );
 
-/// The width/height of the circle used in the indicator label.
-/// @type Number
-/// @access private
-$_o-labels-indicator-circle-size-calc: #{(4/12)}em #{'+'} 6px; // 10px given 12px font size, 12px given 18px font size
-
 /// Whether or not the animation keyframes for the live indicator
 /// label has already been output.
 /// @type Boolean


### PR DESCRIPTION
- Use whole numbers for the indicator circle, to avoid subpixel
rendering issues: https://github.com/Financial-Times/o-labels/pull/103
- Update live animation as proposed by Josh from Content Innovation
and approved in the design ops meeting https://github.com/Financial-Times/o-labels/issues/101

before (note misshapen indicator section along on the first line):
![Screenshot_2020-11-11 o-labels indicators demo](https://user-images.githubusercontent.com/10405691/98829508-30767880-2431-11eb-9705-eff3a81c616f.png)

after:
![Screenshot_2020-11-11 o-labels indicators demo(1)](https://user-images.githubusercontent.com/10405691/98829528-366c5980-2431-11eb-9bb4-ff9232c2c749.png)

animation before:
![Kapture 2020-11-11 at 15 14 30](https://user-images.githubusercontent.com/10405691/98829745-7a5f5e80-2431-11eb-9e20-33738a07a506.gif)

animation after:
![Kapture 2020-11-11 at 15 14 09](https://user-images.githubusercontent.com/10405691/98829678-6582cb00-2431-11eb-92c4-7c544178d5cc.gif)
