### PR TITLE
Add colour palette based states for the internal brand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This table outlines the possible standard label sizes.
 
 This table outlines the possible standard label states. Custom states may also be created.
 
-| Size                 | Description                                                   | Brand support |
+| State                | Description                                                   | Brand support |
 |----------------------|---------------------------------------------------------------|---------------|
 | content-commercial   | Used to identify paid posts or promoted content.              | master        |
 | content-premium      | Used to identify premium content.                             | master        |
@@ -52,6 +52,13 @@ This table outlines the possible standard label states. Custom states may also b
 | tier-gold            | Used to indicate a service with a gold service tier.          | internal      |
 | tier-silver          | Used to indicate a service with a silver service tier.        | internal      |
 | tier-bronze          | Used to indicate a service with a bronze service tier.        | internal      |
+| oxford               | A colour based label with no specific meaning specified.      | internal      |
+| teal                 | A colour based label with no specific meaning specified.      | internal      |
+| lemon                | A colour based label with no specific meaning specified.      | internal      |
+| slate                | A colour based label with no specific meaning specified.      | internal      |
+| jade                 | A colour based label with no specific meaning specified.      | internal      |
+| crimson              | A colour based label with no specific meaning specified.      | internal      |
+| mandarin             | A colour based label with no specific meaning specified.      | internal      |
 
 ### Indicator Label
 
@@ -61,7 +68,7 @@ The indicator label is used to show story status with new, updated, and live var
 
 This table outlines the possible indicator label statuses:
 
-| Size                 | Description                                                   | Brand support |
+| Indicator            | Description                                                   | Brand support |
 |----------------------|---------------------------------------------------------------|---------------|
 | live                 | Indicate a story is live.                                     | master        |
 | closed               | Indicate a live story is no longer live.                      | master        |
@@ -123,6 +130,18 @@ The following internal brand states are used to represent the FT's service tiers
 <span class="o-labels o-labels--support-gold">Gold</span>
 <span class="o-labels o-labels--support-silver">Silver</span>
 <span class="o-labels o-labels--support-bronze">Bronze</span>
+```
+
+The internal brand may also use colour palette based states, these do not specify a particular usecase for flexibility:
+
+```html
+<span class="o-labels o-labels--oxford">oxford</span>
+<span class="o-labels o-labels--teal">teal</span>
+<span class="o-labels o-labels--lemon">lemon</span>
+<span class="o-labels o-labels--slate">slate</span>
+<span class="o-labels o-labels--jade">jade</span>
+<span class="o-labels o-labels--crimson">crimson</span>
+<span class="o-labels o-labels--mandarin">mandarin</span>
 ```
 
 ### Indicator Label Markup

--- a/demos/src/data/color-palette-states.json
+++ b/demos/src/data/color-palette-states.json
@@ -1,0 +1,32 @@
+{
+	"states": [
+		{
+			"id": "oxford",
+			"content": "oxford"
+		},
+		{
+			"id": "teal",
+			"content": "teal"
+		},
+		{
+			"id": "lemon",
+			"content": "lemon"
+		},
+		{
+			"id": "slate",
+			"content": "slate"
+		},
+		{
+			"id": "jade",
+			"content": "jade"
+		},
+		{
+			"id": "crimson",
+			"content": "crimson"
+		},
+		{
+			"id": "mandarin",
+			"content": "mandarin"
+		}
+	]
+}

--- a/origami.json
+++ b/origami.json
@@ -77,6 +77,16 @@
 			]
 		},
 		{
+			"name": "palette-states",
+			"title": "Colour Palette States",
+			"description": "Colour palette based states do not specify a particular usecase, and may be used flexibility.",
+			"template": "/demos/src/states.mustache",
+			"data": "demos/src/data/color-palette-states.json",
+			"brands": [
+				"internal"
+			]
+		},
+		{
 			"name": "typography",
 			"title": "Typography",
 			"description": "Labels sitting in line with text that's styled with o-typography.",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -102,6 +102,27 @@ $_o-labels-shared-brand-config: (
 				// component needs to use these colours
 				background-color: #c0c0c0
 			),
+			'oxford': (
+				background-color: oColorsByName('oxford')
+			),
+			'teal': (
+				background-color: oColorsByName('teal')
+			),
+			'lemon': (
+				background-color: oColorsByName('lemon')
+			),
+			'slate': (
+				background-color: oColorsByName('slate')
+			),
+			'jade': (
+				background-color: oColorsByName('jade')
+			),
+			'crimson': (
+				background-color: oColorsByName('crimson')
+			),
+			'mandarin': (
+				background-color: oColorsByName('mandarin')
+			)
 		)),
 		'supports-variants': (
 			'big',
@@ -114,7 +135,14 @@ $_o-labels-shared-brand-config: (
 			'tier-bronze',
 			'tier-gold',
 			'tier-platinum',
-			'tier-silver'
+			'tier-silver',
+			'oxford',
+			'teal',
+			'lemon',
+			'slate',
+			'jade',
+			'crimson',
+			'mandarin'
 		)
 	));
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -30,16 +30,27 @@ $_o-labels-standard-sizes: (
 $_o-labels-standard-states: (
 	'content-commercial',
 	'content-premium',
+
 	'lifecycle-beta',
+
 	'support-active',
 	'support-dead',
 	'support-deprecated',
 	'support-experimental',
 	'support-maintained',
+
 	'tier-bronze',
 	'tier-gold',
 	'tier-platinum',
-	'tier-silver'
+	'tier-silver',
+
+	'oxford',
+	'teal',
+	'lemon',
+	'slate',
+	'jade',
+	'crimson',
+	'mandarin'
 );
 
 /// Indicator label states


### PR DESCRIPTION
These do not specify a particular usecase for flexibility.
In the future we may want to alias names to these to guide
when to use which, but right now internal tools are diverse
and use coloured labels for different purposes.

![Screenshot 2021-04-19 at 12 41 27](https://user-images.githubusercontent.com/10405691/115230965-ecd51880-a10c-11eb-8726-73025b91f421.png)


https://github.com/Financial-Times/o-labels/issues/102